### PR TITLE
Change terminology in mover-rsync

### DIFF
--- a/mover-rsync/Dockerfile
+++ b/mover-rsync/Dockerfile
@@ -10,14 +10,14 @@ RUN yum update -y && \
     && yum clean all && \
     rm -rf /var/cache/yum
 
-COPY primary.sh \
-     secondary.sh \
-     secondary-command.sh \
+COPY source.sh \
+     destination.sh \
+     destination-command.sh \
      /
 
-RUN chmod a+rx /primary.sh /secondary.sh \secondary-command.sh && \
-    ln -s /keys/secondary /etc/ssh/ssh_host_rsa_key && \
-    ln -s /keys/secondary.pub /etc/ssh/ssh_host_rsa_key.pub && \
+RUN chmod a+rx /source.sh /destination.sh \destination-command.sh && \
+    ln -s /keys/destination /etc/ssh/ssh_host_rsa_key && \
+    ln -s /keys/destination.pub /etc/ssh/ssh_host_rsa_key.pub && \
     install /usr/share/doc/rsync/support/rrsync /usr/local/bin
 
 ARG builddate="(unknown)"

--- a/mover-rsync/README.md
+++ b/mover-rsync/README.md
@@ -1,18 +1,18 @@
 # Rsync-based data mover
 
 This directory contains the code for the data mover that uses
-[rsync](https://rsync.samba.org/) to transfer data between the primary and
-secondary sites.
+[rsync](https://rsync.samba.org/) to transfer data between the source and
+destination sites.
 
 Until there's an operator to deploy this container, the following files can be
 used for experimentation:
 
-- `make-keys.sh`: This script generates secrets that will allow the primary and
-  secondary to mutually authenticate the ssh connection used for the rsync
+- `make-keys.sh`: This script generates secrets that will allow the source and
+  destination to mutually authenticate the ssh connection used for the rsync
   transfer.
-- `deploy-primary.yaml`: This contains the manifests for the primary site. It
-  references the `primary-secret` that was created by `make-keys.sh`. You will
-  need to update the address of the secondary site in this file.
-- `deploy-secondary.yaml`: This contains the manifests for the secondary site.
-  It needs `secondary-secret`, also created by `make-keys.sh`. You may need to
-  update the Service definition depending on how you deploy.
+- `deploy-source.yaml`: This contains the manifests for the source site. It
+  references the `source-secret` that was created by `make-keys.sh`. You will
+  need to update the address of the destination site in this file.
+- `deploy-destination.yaml`: This contains the manifests for the destination
+  site. It needs `destination-secret`, also created by `make-keys.sh`. You may
+  need to update the Service definition depending on how you deploy.

--- a/mover-rsync/deploy-destination.yaml
+++ b/mover-rsync/deploy-destination.yaml
@@ -2,7 +2,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: secondary-data
+  name: destination-data
 spec:
   accessModes: ["ReadWriteOnce"]
   resources:
@@ -13,19 +13,19 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: scribe-rsync-secondary
+  name: scribe-rsync-destination
 spec:
   template:
     metadata:
-      name: scribe-rsync-secondary
+      name: scribe-rsync-destination
       labels:
-        app.kubernetes.io/name: rsync-sink
+        app.kubernetes.io/name: rsync-destination
         app.kubernetes.io/component: mover
         app.kubernetes.io/part-of: scribe
     spec:
       containers:
         - name: rsync
-          command: ["/bin/bash", "-c", "/secondary.sh"]
+          command: ["/bin/bash", "-c", "/destination.sh"]
           image: quay.io/backube/scribe-mover-rsync:latest
           imagePullPolicy: IfNotPresent
           volumeMounts:
@@ -41,20 +41,20 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: secondary-data
+            claimName: destination-data
         - name: keys
           secret:
-            secretName: secondary-secret
+            secretName: destination-secret
             defaultMode: 0600
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: scribe-rsync-secondary
+  name: scribe-rsync-destination
 spec:
   selector:
-    app.kubernetes.io/name: rsync-sink
+    app.kubernetes.io/name: rsync-destination
     app.kubernetes.io/component: mover
     app.kubernetes.io/part-of: scribe
   ports:

--- a/mover-rsync/deploy-source.yaml
+++ b/mover-rsync/deploy-source.yaml
@@ -2,7 +2,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: primary-data
+  name: source-data
 spec:
   accessModes: ["ReadWriteOnce"]
   resources:
@@ -13,22 +13,22 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: scribe-rsync-primary
+  name: scribe-rsync-source
 spec:
   template:
     metadata:
-      name: scribe-rsync-primary
+      name: scribe-rsync-source
       labels:
-        app.kubernetes.io/name: rsync-primary
+        app.kubernetes.io/name: rsync-source
         app.kubernetes.io/component: mover
         app.kubernetes.io/part-of: scribe
     spec:
       containers:
         - name: rsync
-          command: ["/bin/bash", "-c", "/primary.sh"]
+          command: ["/bin/bash", "-c", "/source.sh"]
           env:
-            - name: SECONDARY_ADDRESS
-              value: scribe-rsync-secondary.scribe.svc.cluster.local
+            - name: DESTINATION_ADDRESS
+              value: scribe-rsync-destination.scribe.svc.cluster.local
           image: quay.io/backube/scribe-mover-rsync:latest
           imagePullPolicy: IfNotPresent
           volumeMounts:
@@ -44,9 +44,9 @@ spec:
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: primary-data
+            claimName: source-data
             readOnly: true
         - name: keys
           secret:
-            secretName: primary-secret
+            secretName: source-secret
             defaultMode: 0600

--- a/mover-rsync/destination-command.sh
+++ b/mover-rsync/destination-command.sh
@@ -20,11 +20,11 @@ function do_rsync {
     LANG=C rrsync /data
 }
 
-#-- These are the only commands allowed to be executed by the primary side:
-# Primary can initiate an rsync
+#-- These are the only commands allowed to be executed by the source side:
+# Source can initiate an rsync
 if [[ "$SSH_ORIGINAL_COMMAND" =~ ^rsync( ) ]]; then
     do_rsync
-# Primary can tell us (secondary) to shutdown & pass a numeric result code
+# Source can tell us (destination) to shutdown & pass a numeric result code
 elif [[ "$SSH_ORIGINAL_COMMAND" =~ ^shutdown( )+([0-9]+)$ ]]; then
     do_shutdown "${BASH_REMATCH[2]}"
 # Everything else is an error

--- a/mover-rsync/destination.sh
+++ b/mover-rsync/destination.sh
@@ -12,10 +12,10 @@ sed -ir 's|^[#\s]*\(AllowTcpForwarding\)\s.*$|\1 no|' "$SSHD_CONFIG"
 sed -ir 's|^[#\s]*\(X11Forwarding\)\s.*$|\1 no|' "$SSHD_CONFIG"
 sed -ir 's|^[#\s]*\(PermitTunnel\)\s.*$|\1 no|' "$SSHD_CONFIG"
 
-# Allow primary's key to access, but restrict what it can do.
+# Allow source's key to access, but restrict what it can do.
 mkdir -p ~/.ssh
 chmod 700 ~/.ssh
-echo "command=\"/secondary-command.sh\",restrict $(</keys/primary.pub)" > ~/.ssh/authorized_keys
+echo "command=\"/destination-command.sh\",restrict $(</keys/source.pub)" > ~/.ssh/authorized_keys
 
 # Wait for incoming rsync transfer
 echo "Waiting for connection..."

--- a/mover-rsync/make-keys.sh
+++ b/mover-rsync/make-keys.sh
@@ -5,8 +5,8 @@ set -e -o pipefail
 # We always use RSA keys since the other types are either insecure or not
 # available in FIPS mode
 
-PRIMARY=primary-key
-SECONDARY=secondary-key
+SOURCE=source-key
+DESTINATION=destination-key
 
 function gen-key {
     OUTFILE="$1"
@@ -15,33 +15,33 @@ function gen-key {
     ssh-keygen -q -t rsa -b 4096 -f "$OUTFILE" -C '' -N '' 
 }
 
-gen-key "$PRIMARY"
-gen-key "$SECONDARY"
+gen-key "$SOURCE"
+gen-key "$DESTINATION"
 
-cat - <<PRIMARY > primary-secret.yaml
+cat - <<SOURCE > source-secret.yaml
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: primary-secret
+  name: source-secret
 type: Opaque
 data:
-  primary: $(base64 -w0 < "$PRIMARY")
-  primary.pub: $(base64 -w0 < "$PRIMARY.pub")
-  secondary.pub: $(base64 -w0 < "$SECONDARY.pub")
-PRIMARY
+  source: $(base64 -w0 < "$SOURCE")
+  source.pub: $(base64 -w0 < "$SOURCE.pub")
+  destination.pub: $(base64 -w0 < "$DESTINATION.pub")
+SOURCE
 
-cat - <<SECONDARY > secondary-secret.yaml
+cat - <<DESTINATION > destination-secret.yaml
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: secondary-secret
+  name: destination-secret
 type: Opaque
 data:
-  primary.pub: $(base64 -w0 < "$PRIMARY.pub")
-  secondary: $(base64 -w0 < "$SECONDARY")
-  secondary.pub: $(base64 -w0 < "$SECONDARY.pub")
-SECONDARY
+  source.pub: $(base64 -w0 < "$SOURCE.pub")
+  destination: $(base64 -w0 < "$DESTINATION")
+  destination.pub: $(base64 -w0 < "$DESTINATION.pub")
+DESTINATION
 
-rm -f "${PRIMARY}" "${PRIMARY}.pub" "${SECONDARY}" "${SECONDARY}.pub"
+rm -f "${SOURCE}" "${SOURCE}.pub" "${DESTINATION}" "${DESTINATION}.pub"


### PR DESCRIPTION
**Describe what this PR does**
When discussing replication for DR, where the secondary site would want
to replicate back to the primary after recovery, the terminology was
confusing. Source & destination make it much more clear, given the
one-way nature of the replication relationships.

Primary :arrow_right: Source 
Secondary :arrow_right: Destination

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
