### PR TITLE
Decrease mover connection timeout

### DIFF
--- a/mover-rsync/source.sh
+++ b/mover-rsync/source.sh
@@ -17,6 +17,8 @@ echo "$DESTINATION_ADDRESS $(</keys/destination.pub)" > ~/.ssh/known_hosts
 
 cat - <<SSHCONFIG > ~/.ssh/config
 Host *
+  # Wait max 30s to establish connection
+  ConnectTimeout 30
   # Control persist to speed 2nd ssh connection
   ControlMaster auto
   ControlPath ~/.ssh/controlmasters/%C


### PR DESCRIPTION
**Describe what this PR does**
The mover took a long time to timeout if not able to immediately connect, and during that time, the TCP syn backoff made the connection latency quite long if the destination did become available. This decreases the timeout to 30s, causing the pod to restart if no connection is made.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
