### PR TITLE
Add common source volume handling

### DIFF
--- a/api/v1alpha1/replicationdestination_types.go
+++ b/api/v1alpha1/replicationdestination_types.go
@@ -170,6 +170,10 @@ type ReplicationDestinationStatus struct {
 	// update.
 	//+optional
 	LastSyncDuration *metav1.Duration `json:"lastSyncDuration,omitempty"`
+	// nextSyncTime is the time when the next volume synchronization is
+	// scheduled to start (for schedule-based synchronization).
+	//+optional
+	NextSyncTime *metav1.Time `json:"nextSyncTime,omitempty"`
 	// latestImage in the object holding the most recent consistent replicated
 	// image.
 	//+optional
@@ -192,6 +196,7 @@ type ReplicationDestinationStatus struct {
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Last sync",type="string",format="date-time",JSONPath=`.status.lastSyncTime`
 //+kubebuilder:printcolumn:name="Duration",type="string",JSONPath=`.status.lastSyncDuration`
+//+kubebuilder:printcolumn:name="Next sync",type="string",format="date-time",JSONPath=`.status.nextSyncTime`
 type ReplicationDestination struct {
 	metav1.TypeMeta `json:",inline"`
 	//+optional

--- a/api/v1alpha1/replicationsource_types.go
+++ b/api/v1alpha1/replicationsource_types.go
@@ -166,6 +166,10 @@ type ReplicationSourceStatus struct {
 	// update.
 	//+optional
 	LastSyncDuration *metav1.Duration `json:"lastSyncDuration,omitempty"`
+	// nextSyncTime is the time when the next volume synchronization is
+	// scheduled to start (for schedule-based synchronization).
+	//+optional
+	NextSyncTime *metav1.Time `json:"nextSyncTime,omitempty"`
 	// rsync contains status information for Rsync-based replication.
 	Rsync *ReplicationSourceRsyncStatus `json:"rsync,omitempty"`
 	// external contains provider-specific status information. For more details,
@@ -185,6 +189,7 @@ type ReplicationSourceStatus struct {
 //+kubebuilder:printcolumn:name="Source",type="string",JSONPath=`.spec.sourcePVC`
 //+kubebuilder:printcolumn:name="Last sync",type="string",format="date-time",JSONPath=`.status.lastSyncTime`
 //+kubebuilder:printcolumn:name="Duration",type="string",JSONPath=`.status.lastSyncDuration`
+//+kubebuilder:printcolumn:name="Next sync",type="string",format="date-time",JSONPath=`.status.nextSyncTime`
 type ReplicationSource struct {
 	metav1.TypeMeta `json:",inline"`
 	//+optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -264,6 +264,10 @@ func (in *ReplicationDestinationStatus) DeepCopyInto(out *ReplicationDestination
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.NextSyncTime != nil {
+		in, out := &in.NextSyncTime, &out.NextSyncTime
+		*out = (*in).DeepCopy()
+	}
 	if in.LatestImage != nil {
 		in, out := &in.LatestImage, &out.LatestImage
 		*out = new(v1.TypedLocalObjectReference)
@@ -579,6 +583,10 @@ func (in *ReplicationSourceStatus) DeepCopyInto(out *ReplicationSourceStatus) {
 		in, out := &in.LastSyncDuration, &out.LastSyncDuration
 		*out = new(metav1.Duration)
 		**out = **in
+	}
+	if in.NextSyncTime != nil {
+		in, out := &in.NextSyncTime, &out.NextSyncTime
+		*out = (*in).DeepCopy()
 	}
 	if in.Rsync != nil {
 		in, out := &in.Rsync, &out.Rsync

--- a/config/crd/bases/scribe.backube_replicationdestinations.yaml
+++ b/config/crd/bases/scribe.backube_replicationdestinations.yaml
@@ -24,6 +24,10 @@ spec:
     - jsonPath: .status.lastSyncDuration
       name: Duration
       type: string
+    - format: date-time
+      jsonPath: .status.nextSyncTime
+      name: Next sync
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -275,6 +279,11 @@ spec:
                 - kind
                 - name
                 type: object
+              nextSyncTime:
+                description: nextSyncTime is the time when the next volume synchronization
+                  is scheduled to start (for schedule-based synchronization).
+                format: date-time
+                type: string
               rsync:
                 description: rsync contains status information for Rsync-based replication.
                 properties:

--- a/config/crd/bases/scribe.backube_replicationsources.yaml
+++ b/config/crd/bases/scribe.backube_replicationsources.yaml
@@ -27,6 +27,10 @@ spec:
     - jsonPath: .status.lastSyncDuration
       name: Duration
       type: string
+    - format: date-time
+      jsonPath: .status.nextSyncTime
+      name: Next sync
+      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -247,6 +251,11 @@ spec:
               lastSyncTime:
                 description: lastSyncTime is the time of the most recent successful
                   synchronization.
+                format: date-time
+                type: string
+              nextSyncTime:
+                description: nextSyncTime is the time when the next volume synchronization
+                  is scheduled to start (for schedule-based synchronization).
                 format: date-time
                 type: string
               rsync:

--- a/controllers/replicationdestination_controller.go
+++ b/controllers/replicationdestination_controller.go
@@ -134,21 +134,6 @@ func (r *ReplicationDestinationReconciler) SetupWithManager(mgr ctrl.Manager) er
 		Complete(r)
 }
 
-// reconcileFunc is a function that partially reconciles an object. It returns a
-// bool indicating whether reconciling should continue and an error.
-type reconcileFunc func(logr.Logger) (bool, error)
-
-// reconcileBatch steps through a list of reconcile functions until one returns
-// false or an error.
-func reconcileBatch(l logr.Logger, reconcileFuncs ...reconcileFunc) (bool, error) {
-	for _, f := range reconcileFuncs {
-		if cont, err := f(l); !cont || err != nil {
-			return cont, err
-		}
-	}
-	return true, nil
-}
-
 type rsyncDestReconciler struct {
 	destinationVolumeHandler
 	service    *corev1.Service

--- a/controllers/replicationdestination_test.go
+++ b/controllers/replicationdestination_test.go
@@ -3,36 +3,21 @@ package controllers
 
 import (
 	"context"
-	"time"
 
-	//snapv1 "github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/operator-framework/operator-lib/status"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	//batchv1 "k8s.io/api/batch/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
-
-	//"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-
-	//"k8s.io/apimachinery/pkg/types"
-	//"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	scribev1alpha1 "github.com/backube/scribe/api/v1alpha1"
-)
-
-const (
-	duration = 5 * time.Second
-	maxWait  = 60 * time.Second
-	interval = 250 * time.Millisecond
 )
 
 var _ = Describe("ReplicationDestination", func() {

--- a/controllers/replicationsource_test.go
+++ b/controllers/replicationsource_test.go
@@ -1,0 +1,209 @@
+//nolint:lll
+
+package controllers
+
+import (
+	"context"
+
+	scribev1alpha1 "github.com/backube/scribe/api/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("ReplicationSource", func() {
+	var ctx = context.Background()
+	var namespace *corev1.Namespace
+	var rs *scribev1alpha1.ReplicationSource
+	var srcPVC *corev1.PersistentVolumeClaim
+	srcPVCCapacity := resource.MustParse("7Gi")
+
+	BeforeEach(func() {
+		// Each test is run in its own namespace
+		namespace = &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "scribe-test-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, namespace)).To(Succeed())
+		Expect(namespace.Name).NotTo(BeEmpty())
+
+		srcPVC = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "thesource",
+				Namespace: namespace.Name,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: srcPVCCapacity,
+					},
+				},
+			},
+		}
+
+		// Scaffold the ReplicationSource, but don't create so that it can
+		// be customized per test scenario.
+		rs = &scribev1alpha1.ReplicationSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "instance",
+				Namespace: namespace.Name,
+			},
+			Spec: scribev1alpha1.ReplicationSourceSpec{
+				SourcePVC: srcPVC.Name,
+			},
+		}
+		RsyncContainerImage = DefaultRsyncContainerImage
+	})
+	AfterEach(func() {
+		// All resources are namespaced, so this should clean it all up
+		Expect(k8sClient.Delete(ctx, namespace)).To(Succeed())
+	})
+	JustBeforeEach(func() {
+		Expect(k8sClient.Create(ctx, srcPVC)).To(Succeed())
+		// ReplicationSource should have been customized in the BeforeEach
+		// at each level, so now we create it.
+		Expect(k8sClient.Create(ctx, rs)).To(Succeed())
+		// Wait for it to show up in the API server
+		Eventually(func() error {
+			inst := &scribev1alpha1.ReplicationSource{}
+			return k8sClient.Get(ctx, nameFor(rs), inst)
+		}, maxWait, interval).Should(Succeed())
+	})
+
+	Context("when an external replication method is specified", func() {
+		BeforeEach(func() {
+			rs.Spec.External = &scribev1alpha1.ReplicationSourceExternalSpec{}
+		})
+		It("the CR is not reconciled", func() {
+			Consistently(func() *scribev1alpha1.ReplicationSourceStatus {
+				Expect(k8sClient.Get(ctx, nameFor(rs), rs)).To(Succeed())
+				return rs.Status
+			}, duration, interval).Should(BeNil())
+		})
+	})
+
+	Context("when a schedule is specified", func() {
+		BeforeEach(func() {
+			rs.Spec.Rsync = &scribev1alpha1.ReplicationSourceRsyncSpec{
+				ReplicationSourceVolumeOptions: scribev1alpha1.ReplicationSourceVolumeOptions{
+					CopyMethod: scribev1alpha1.CopyMethodNone,
+				},
+			}
+			schedule := "* * * * *"
+			rs.Spec.Trigger = &scribev1alpha1.ReplicationSourceTriggerSpec{
+				Schedule: &schedule,
+			}
+		})
+		It("the next sync time is set in .status.nextSyncTime", func() {
+			Eventually(func() bool {
+				Expect(k8sClient.Get(ctx, nameFor(rs), rs)).To(Succeed())
+				if rs.Status == nil || rs.Status.NextSyncTime.IsZero() {
+					return false
+				}
+				return true
+			}, maxWait, interval).Should(BeTrue())
+		})
+	})
+
+	Context("when a schedule is not specified", func() {
+		BeforeEach(func() {
+			rs.Spec.Rsync = &scribev1alpha1.ReplicationSourceRsyncSpec{
+				ReplicationSourceVolumeOptions: scribev1alpha1.ReplicationSourceVolumeOptions{
+					CopyMethod: scribev1alpha1.CopyMethodNone,
+				},
+			}
+		})
+		It("the next sync time is nil", func() {
+			Consistently(func() bool {
+				Expect(k8sClient.Get(ctx, nameFor(rs), rs)).To(Succeed())
+				if rs.Status == nil || rs.Status.NextSyncTime.IsZero() {
+					return false
+				}
+				return true
+			}, duration, interval).Should(BeFalse())
+		})
+	})
+
+	Context("when a copyMethod of None is specified", func() {
+		BeforeEach(func() {
+			rs.Spec.Rsync = &scribev1alpha1.ReplicationSourceRsyncSpec{
+				ReplicationSourceVolumeOptions: scribev1alpha1.ReplicationSourceVolumeOptions{
+					CopyMethod: scribev1alpha1.CopyMethodNone,
+				},
+			}
+		})
+		JustBeforeEach(func() {
+			// TODO: Find the sync Job and its PVC
+		})
+		It("uses the source PVC as the sync source", func() {
+			// TODO: Check the sync Job to make sure it's using the source PVC
+		})
+	})
+
+	Context("when a copyMethod of Clone is specified", func() {
+		BeforeEach(func() {
+			rs.Spec.Rsync = &scribev1alpha1.ReplicationSourceRsyncSpec{
+				ReplicationSourceVolumeOptions: scribev1alpha1.ReplicationSourceVolumeOptions{
+					CopyMethod: scribev1alpha1.CopyMethodClone,
+				},
+			}
+		})
+		JustBeforeEach(func() {
+			// TODO: Find the sync Job and its PVC
+		})
+		It("creates a clone of the source PVC as the sync source", func() {
+			// TODO: Check the sync Job to make sure it's using a PVC w/ a
+			// DataSource that matches srcPVC
+		})
+
+		Context("SC, capacity, accessModes can be overridden", func() {
+			newSC := "mysc2"
+			newCapacity := resource.MustParse("1Gi")
+			newAccessModes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+			BeforeEach(func() {
+				rs.Spec.Rsync.StorageClassName = &newSC
+				rs.Spec.Rsync.Capacity = &newCapacity
+				rs.Spec.Rsync.AccessModes = newAccessModes
+			})
+			It("cloned PVC has overridden values", func() {
+				// TODO: Check the capacity, accessModes, and storageClassName
+			})
+		})
+	})
+
+	Context("when a copyMethod of Snapshot is specified", func() {
+		BeforeEach(func() {
+			rs.Spec.Rsync = &scribev1alpha1.ReplicationSourceRsyncSpec{
+				ReplicationSourceVolumeOptions: scribev1alpha1.ReplicationSourceVolumeOptions{
+					CopyMethod: scribev1alpha1.CopyMethodSnapshot,
+				},
+			}
+		})
+		JustBeforeEach(func() {
+			// TODO: Find the sync Job and its PVC
+		})
+		It("creates a snapshot of the source PVC and restores it as the sync source", func() {
+			// TODO: Check the sync Job to make sure it's using a PVC w/ a
+			// DataSource that is a VolumeSnapshot
+		})
+
+		Context("SC, capacity, accessModes can be overridden", func() {
+			newSC := "mysc2"
+			newCapacity := resource.MustParse("1Gi")
+			newAccessModes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+			BeforeEach(func() {
+				rs.Spec.Rsync.StorageClassName = &newSC
+				rs.Spec.Rsync.Capacity = &newCapacity
+				rs.Spec.Rsync.AccessModes = newAccessModes
+			})
+			It("new PVC has overridden values", func() {
+				// TODO: Check the capacity, accessModes, and storageClassName
+			})
+		})
+	})
+})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"time"
 
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
 	. "github.com/onsi/ginkgo"
@@ -38,6 +39,12 @@ import (
 
 	scribev1alpha1 "github.com/backube/scribe/api/v1alpha1"
 	// +kubebuilder:scaffold:imports
+)
+
+const (
+	duration = 5 * time.Second
+	maxWait  = 60 * time.Second
+	interval = 250 * time.Millisecond
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -97,6 +104,13 @@ var _ = BeforeSuite(func(done Done) {
 	err = (&ReplicationDestinationReconciler{
 		Client: k8sManager.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("Destination"),
+		Scheme: k8sManager.GetScheme(),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
+	err = (&ReplicationSourceReconciler{
+		Client: k8sManager.GetClient(),
+		Log:    ctrl.Log.WithName("controllers").WithName("Source"),
 		Scheme: k8sManager.GetScheme(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -168,11 +167,4 @@ func (m *ownerRefMatcher) FailureMessage(actual interface{}) (message string) {
 }
 func (m *ownerRefMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	return fmt.Sprintf("Expected\n\t%#v\nnot to be owned by\n\t%#v", actual, m.owner)
-}
-
-func nameFor(obj metav1.Object) types.NamespacedName {
-	return types.NamespacedName{
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-	}
 }

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Scribe authors.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package controllers
+
+import (
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func nameFor(obj metav1.Object) types.NamespacedName {
+	return types.NamespacedName{
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
+}
+
+// reconcileFunc is a function that partially reconciles an object. It returns a
+// bool indicating whether reconciling should continue and an error.
+type reconcileFunc func(logr.Logger) (bool, error)
+
+// reconcileBatch steps through a list of reconcile functions until one returns
+// false or an error.
+func reconcileBatch(l logr.Logger, reconcileFuncs ...reconcileFunc) (bool, error) {
+	for _, f := range reconcileFuncs {
+		if cont, err := f(l); !cont || err != nil {
+			return cont, err
+		}
+	}
+	return true, nil
+}

--- a/controllers/volumehandler.go
+++ b/controllers/volumehandler.go
@@ -42,13 +42,6 @@ const (
 	timeYYYYMMDDHHMMSS = "20060102150405"
 )
 
-func nameFor(obj metav1.Object) types.NamespacedName {
-	return types.NamespacedName{
-		Name:      obj.GetName(),
-		Namespace: obj.GetNamespace(),
-	}
-}
-
 type destinationVolumeHandler struct {
 	ReplicationDestinationReconciler
 	Ctx      context.Context

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/operator-framework/operator-lib v0.1.0
+	github.com/robfig/cron/v3 v3.0.1
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6

--- a/go.sum
+++ b/go.sum
@@ -303,6 +303,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=


### PR DESCRIPTION
**Describe what this PR does**
This adds the code for the common portions of the source volume handling.
- Making a clone of the source PVC to get temporary PVC (copy type Clone)
- Creating the temporary PVC via snapshot and restore (copy type Snapshot)
- Using source PVC directly (copy type None)
- Cleanup of the temporary volumes created by above

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Related to #15 - Verification of the test cases is still pending (Source reconciler needs to be built out first)
