### PR TITLE
renaming to be properly used by mergify

### DIFF
--- a/.github/workflows/mover-rsync.yml
+++ b/.github/workflows/mover-rsync.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   lint:
-    name: Lint
+    name: Lint mover-rsync
     runs-on: ubuntu-latest
 
     steps:
@@ -33,7 +33,7 @@ jobs:
         run: ./.ci-scripts/pre-commit.sh --require-all
 
   build:
-    name: Build
+    name: Build mover-rsync
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   lint:
-    name: Lint
+    name: Lint operator
     runs-on: ubuntu-latest
 
     steps:
@@ -33,7 +33,7 @@ jobs:
         run: ./.ci-scripts/pre-commit.sh --require-all
 
   build:
-    name: Build
+    name: Build operator
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
**Describe what this PR does**
This is to rename the jobs so they can be properly parsed by mergify. Right now it just picks a lint or a build to use not both.

**Is there anything that requires special attention?**
This can be reverted if it does not operate as expected

**Related issues:**

