### PR TITLE
Switch GH actions to use ubuntu-20.04

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout source
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo 'APT::Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/80-retries
           sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip python3-venv
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip python3-venv
 
       - name: Build docs
         run: |

--- a/.github/workflows/mover-rsync.yml
+++ b/.github/workflows/mover-rsync.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   lint:
     name: Lint-mover-rsync
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout source
@@ -26,15 +26,15 @@ jobs:
         run: |
           echo 'APT::Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/80-retries
           sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip ruby
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip ruby
           sudo gem install asciidoctor mdl
-          sudo pip install yamllint
+          sudo pip3 install yamllint
       - name: Run linters
         run: ./.ci-scripts/pre-commit.sh --require-all
 
   build:
     name: Build-mover-rsync
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout source
@@ -58,7 +58,7 @@ jobs:
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Load container artifact

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout source
@@ -26,15 +26,15 @@ jobs:
         run: |
           echo 'APT::Acquire::Retries "5";' | sudo tee /etc/apt/apt.conf.d/80-retries
           sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip ruby
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip ruby
           sudo gem install asciidoctor mdl
-          sudo pip install yamllint
+          sudo pip3 install yamllint
       - name: Run linters
         run: ./.ci-scripts/pre-commit.sh --require-all
 
   build:
     name: Build-operator
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout source
@@ -65,7 +65,7 @@ jobs:
   e2e:
     name: End-to-end
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +86,7 @@ jobs:
     if: >
       (github.event_name == 'push' || github.event_name == 'schedule') &&
       (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Load container artifact


### PR DESCRIPTION
**Describe what this PR does**
We ran into a problem with package versions while trying to install the
mdl linter. GH is currently in the process of updating the ubuntu-latest
runner to 20.04. This commit just moves us forward a bit ahead of the
forced move.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes #37 
