### PR TITLE
rclone-mover yamls

### DIFF
--- a/mover-rclone/README.md
+++ b/mover-rclone/README.md
@@ -1,0 +1,47 @@
+# Rclone-based data mover
+
+## Getting started
+
+This directory contains the code for the data mover that uses rclone to
+transfer data between the source and destination sites using volumesnapshot
+feature.
+
+AWS S3 is used as an intermediate storage for high fan-out data replication.
+
+Until there's an operator to deploy this container, the following steps can be
+used for experimentation.
+
+### Prerequiste
+
+Create secret to access AWS S3 account by replacing `<access-key-id>` and
+`<secret-access-key>` in `rclone.conf`
+
+```shell
+[aws-s3-bucket]
+type = s3
+provider = AWS
+env_auth = false
+access_key_id = <access_key_id>
+secret_access_key = <secret_access_key>
+region = <region>
+location_constraint = <location_constraint>
+acl = private
+```
+
+`oc create secret generic rclone-secret --from-file=rclone.conf=rclone.conf`
+
+### Test
+
+- `deploysource.yaml`
+
+This script creates a `volumesnapshot` of the source pvc.
+Next it creates a `mover-rclone-pv-claim` from the `volumesnapshot`.
+Job `mover-rclone` copies the data from `mover-rclone-pv-claim` to AWS S3 defined
+by `RCLONE_CONFIG_SECTION:RCLONE_DEST_PATH`
+
+- `deploydestination.yaml`
+
+This script creates a `mover-rclone-pv-claim` that will
+store incoming data from source. Next it create a job `mover-rclone` that copies
+the data from AWS S3 defined by `RCLONE_CONFIG_SECTION:RCLONE_DEST_PATH` to
+`mover-rclone-pv-claim`

--- a/mover-rclone/active.sh
+++ b/mover-rclone/active.sh
@@ -9,10 +9,7 @@ function error {
     exit "$rc"
 }
 
-# Rclone config file gets mounted as a Secret onto /rclone-config
-RCLONE_CONFIG=/rclone-config/rclone.conf
-# Which remote to use in the Rclone config file
-RCLONE_CONFIG_SECTION=default
+# Rclone config file that gets mounted as a Secret onto RCLONE_CONFIG
 
 [[ -n "${RCLONE_DEST_PATH}" ]] || error 1 "RCLONE_DEST_PATH must be defined"
 [[ -n "${DIRECTION}" ]] || error 1 "DIRECTION must be defined"
@@ -22,11 +19,11 @@ RCLONE_FLAGS=(--checksum --one-file-system --create-empty-src-dirs --progress --
 START_TIME=$SECONDS
 case "${DIRECTION}" in
 source)
-    rclone --config "${RCLONE_CONFIG}" sync "${RCLONE_FLAGS[@]}" /data "${RCLONE_CONFIG_SECTION}:${RCLONE_DEST_PATH}"
+    rclone sync "${RCLONE_FLAGS[@]}" "${MOUNT_PATH}" "${RCLONE_CONFIG_SECTION}:${RCLONE_DEST_PATH}"
     rc=$?
     ;;
 destination)
-    rclone --config "${RCLONE_CONFIG}" sync "${RCLONE_FLAGS[@]}" "${RCLONE_CONFIG_SECTION}:${RCLONE_DEST_PATH}" /data
+    rclone sync "${RCLONE_FLAGS[@]}" "${RCLONE_CONFIG_SECTION}:${RCLONE_DEST_PATH}" "${MOUNT_PATH}"
     rc=$?
     ;;
 *)

--- a/mover-rclone/deploydestination.yaml
+++ b/mover-rclone/deploydestination.yaml
@@ -1,0 +1,53 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: mover-rclone-pv-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: gp2-csi
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mover-rclone
+spec:
+  template:
+    metadata:
+      name: mover-rclone
+    spec:
+      containers:
+        - name: scribe-mover-rclone
+          image: quay.io/backube/scribe-mover-rclone
+          command: ["./active.sh"]
+          env:
+            - name: RCLONE_CONFIG
+              value: /rclone-config/rclone.conf
+            - name: RCLONE_DEST_PATH
+              value: scribe-test-bucket
+            - name: DIRECTION
+              value: destination
+            - name: MOUNT_PATH
+              value: /data
+            - name: RCLONE_CONFIG_SECTION
+              value: aws-s3-bucket
+          volumeMounts:
+            # name must match the volume name below
+            - name: rclone-secret
+              mountPath: /rclone-config/
+              readOnly: true
+            - name: snapshot-data
+              mountPath: /data
+      volumes:
+        - name: rclone-secret
+          secret:
+            secretName: rclone-secret
+        - name: snapshot-data
+          persistentVolumeClaim:
+            claimName: mover-rclone-pv-claim
+      restartPolicy: Never

--- a/mover-rclone/deploysource.yaml
+++ b/mover-rclone/deploysource.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1beta1
+kind: VolumeSnapshot
+metadata:
+  name: mover-rclone-snapshot
+spec:
+  volumeSnapshotClassName: gp2-csi
+  source:
+    persistentVolumeClaimName: source-pvc
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mover-rclone-pv-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  dataSource:
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+    name: mover-rclone-snapshot
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mover-rclone
+spec:
+  template:
+    metadata:
+      name: mover-rclone
+    spec:
+      containers:
+        - name: scribe-mover-rclone
+          image: quay.io/backube/scribe-mover-rclone
+          command: ["./active.sh"]
+          env:
+            - name: RCLONE_CONFIG
+              value: /rclone-config/rclone.conf
+            - name: RCLONE_DEST_PATH
+              value: scribe-test-bucket
+            - name: DIRECTION
+              value: source
+            - name: MOUNT_PATH
+              value: /data
+            - name: RCLONE_CONFIG_SECTION
+              value: aws-s3-bucket
+          volumeMounts:
+            # name must match the volume name below
+            - name: rclone-secret
+              mountPath: /rclone-config/
+              readOnly: true
+            - name: snapshot-data
+              mountPath: /data
+      volumes:
+        - name: rclone-secret
+          secret:
+            secretName: rclone-secret
+        - name: snapshot-data
+          persistentVolumeClaim:
+            claimName: mover-rclone-pv-claim
+      restartPolicy: Never

--- a/mover-rclone/rclone.conf
+++ b/mover-rclone/rclone.conf
@@ -1,0 +1,9 @@
+[aws-s3-bucket]
+type = s3
+provider = AWS
+env_auth = false
+access_key_id = <access_key_id>
+secret_access_key = <secret_access_key>
+region = <region>
+location_constraint = <location_constraint>
+acl = private


### PR DESCRIPTION
**Describe what this PR does**
This PR provides the code for the data mover that uses `rclone` to transfer data between the source and destination sites using `volumesnapshot` feature. Until there's an operator to deploy this container, the following steps can be used for experimentation.

**Is there anything that requires special attention?**
N/A

**Related issues:**
N/A
