### PR TITLE
Restrict the operator's scc access

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -156,6 +156,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - scribe-mover
   resources:
   - securitycontextconstraints
   verbs:

--- a/controllers/replicationdestination_controller.go
+++ b/controllers/replicationdestination_controller.go
@@ -64,7 +64,7 @@ type ReplicationDestinationReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
+//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=scribe-mover,verbs=use
 //+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ReplicationDestinationReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/replicationsource_controller.go
+++ b/controllers/replicationsource_controller.go
@@ -56,7 +56,7 @@ type ReplicationSourceReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use
+//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=scribe-mover,verbs=use
 //+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch;create;update;patch;delete
 
 func (r *ReplicationSourceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
**Describe what this PR does**
This restricts the operator to being able to use its own scc.

Thanks to @guymguym for suggesting!

**Is there anything that requires special attention?**
It wasn't immediately obvious from the docs that this was possible: https://book.kubebuilder.io/reference/markers/rbac.html
However, it was added back in March: https://github.com/kubernetes-sigs/controller-tools/pull/413

**Related issues:**
Related #52 #51 