### PR TITLE
remove the readonly due to directory permissions issues

### DIFF
--- a/controllers/replicationsource_controller.go
+++ b/controllers/replicationsource_controller.go
@@ -379,7 +379,7 @@ func (r *rsyncSrcReconciler) ensureJob(l logr.Logger) (bool, error) {
 			RunAsUser: &runAsUser,
 		}
 		r.job.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
-			{Name: dataVolumeName, MountPath: "/data", ReadOnly: true},
+			{Name: dataVolumeName, MountPath: "/data"},
 			{Name: "keys", MountPath: "/keys"},
 		}
 		r.job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
@@ -389,7 +389,6 @@ func (r *rsyncSrcReconciler) ensureJob(l logr.Logger) (bool, error) {
 			{Name: dataVolumeName, VolumeSource: corev1.VolumeSource{
 				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
 					ClaimName: r.PVC.Name,
-					ReadOnly:  true,
 				}},
 			},
 			{Name: "keys", VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
Signed-off-by: Ryan Cook <rcook@redhat.com>

**Describe what this PR does**
Removes readonly setting that will be applied when a job is created. This will remediate failures where pod uid isn't correct.

**Is there anything that requires special attention?**
N/a

**Related issues:**
#56 

This maybe needs to move to a flag but just trying to wrap some things up for a demo.