### PR TITLE
Add version info to operator & movers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,12 @@ test: generate manifests golangci-lint ginkgo
 # Build manager binary
 .PHONY: manager
 manager: generate
-	go build -o bin/manager main.go
+	go build -o bin/manager -ldflags -X=main.scribeVersion=$(VERSION) main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 .PHONY: run
 run: generate manifests
-	go run ./main.go
+	go run -ldflags -X=main.scribeVersion=$(VERSION) ./main.go
 
 # Install CRDs into a cluster
 .PHONY: install

--- a/controllers/replicationdestination_controller.go
+++ b/controllers/replicationdestination_controller.go
@@ -42,13 +42,16 @@ import (
 const (
 	// DefaultRsyncContainerImage is the default container image name of the rsync data mover
 	DefaultRsyncContainerImage = "quay.io/backube/scribe-mover-rsync:latest"
+	// DefaultRcloneContainerImage is the default container image name of the rclone data mover
+	DefaultRcloneContainerImage = "quay.io/backube/scribe-mover-rclone:latest"
 )
 
-// RsyncContainerImage is the container image name of the rsync data mover
-var RsyncContainerImage string
-
-// RcloneContainerImage is the container image name of the rclone data mover
-var RcloneContainerImage string = "quay.io/backube/scribe-mover-rclone:latest"
+var (
+	// RsyncContainerImage is the container image name of the rsync data mover
+	RsyncContainerImage string
+	// RcloneContainerImage is the container image name of the rclone data mover
+	RcloneContainerImage string
+)
 
 // ReplicationDestinationReconciler reconciles a ReplicationDestination object
 type ReplicationDestinationReconciler struct {

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,13 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v0.1.0
-	github.com/gordonklaus/ineffassign v0.0.0-20210104184537-8eed68eb605f // indirect
 	github.com/kubernetes-csi/external-snapshotter/v2 v2.1.1
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1
 	github.com/operator-framework/operator-lib v0.1.0
 	github.com/robfig/cron/v3 v3.0.1
-	golang.org/x/mod v0.4.0 // indirect
-	golang.org/x/tools v0.0.0-20210113180300-f96436850f18 // indirect
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.6

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,6 @@ github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJ
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
 github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
-github.com/gordonklaus/ineffassign v0.0.0-20210104184537-8eed68eb605f h1:wHGrcNkjqm/QJeljJ9bkFWtND9I0ASarwpBlRcwRymk=
-github.com/gordonklaus/ineffassign v0.0.0-20210104184537-8eed68eb605f/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 h1:pdN6V1QBWetyv/0+wjACpqVH+eVULgEjkurDLq3goeM=
@@ -345,7 +343,6 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
@@ -367,7 +364,6 @@ golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
@@ -381,10 +377,6 @@ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvx
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
-golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
-golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
-golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -417,7 +409,6 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -469,11 +460,7 @@ golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72 h1:bw9doJza/SFBEweII/rHQh338oozWyiFsBRHtrflcws=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20210113180300-f96436850f18 h1:Is2b27nOXPOr/fnTI2XUCWJKFpTsqtnaQj9Kl4Axdb8=
-golang.org/x/tools v0.0.0-20210113180300-f96436850f18/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=

--- a/mover-rclone/Dockerfile
+++ b/mover-rclone/Dockerfile
@@ -14,8 +14,10 @@ COPY active.sh \
 
 RUN chmod a+rx /active.sh
 
-ARG builddate="(unknown)"
-ARG version="(unknown)"
+ARG builddate_arg="(unknown)"
+ARG version_arg="(unknown)"
+ENV builddate="${builddate_arg}"
+ENV version="${version_arg}"
 
 LABEL org.label-schema.build-date="${builddate}" \
       org.label-schema.description="rclone-based data mover for Scribe" \

--- a/mover-rclone/Makefile
+++ b/mover-rclone/Makefile
@@ -9,7 +9,7 @@ all: image
 .PHONY: image
 image:
 	docker build \
-	  --build-arg "builddate=$(BUILDDATE)" \
-	  --build-arg "version=$(VERSION)" \
+	  --build-arg "builddate_arg=$(BUILDDATE)" \
+	  --build-arg "version_arg=$(VERSION)" \
 	  -t $(IMAGE) \
 	  -f Dockerfile .

--- a/mover-rclone/active.sh
+++ b/mover-rclone/active.sh
@@ -2,6 +2,8 @@
 
 set -e -o pipefail
 
+echo "Scribe rclone container version: ${version:-unknown}"
+
 function error {
     rc="$1"
     shift

--- a/mover-rsync/Dockerfile
+++ b/mover-rsync/Dockerfile
@@ -29,8 +29,10 @@ RUN chmod a+rx /source.sh /destination.sh \destination-command.sh && \
     sed -ir 's|^[#\s]*\(X11Forwarding\)\s.*$|\1 no|' "$SSHD_CONFIG" && \
     sed -ir 's|^[#\s]*\(PermitTunnel\)\s.*$|\1 no|' "$SSHD_CONFIG"
 
-ARG builddate="(unknown)"
-ARG version="(unknown)"
+ARG builddate_arg="(unknown)"
+ARG version_arg="(unknown)"
+ENV builddate="${builddate_arg}"
+ENV version="${version_arg}"
 
 LABEL org.label-schema.build-date="${builddate}" \
       org.label-schema.description="rsync-based data mover for Scribe" \

--- a/mover-rsync/Makefile
+++ b/mover-rsync/Makefile
@@ -9,7 +9,7 @@ all: image
 .PHONY: image
 image:
 	docker build \
-	  --build-arg "builddate=$(BUILDDATE)" \
-	  --build-arg "version=$(VERSION)" \
+	  --build-arg "builddate_arg=$(BUILDDATE)" \
+	  --build-arg "version_arg=$(VERSION)" \
 	  -t $(IMAGE) \
 	  -f Dockerfile .

--- a/mover-rsync/destination.sh
+++ b/mover-rsync/destination.sh
@@ -2,6 +2,8 @@
 
 set -e -o pipefail
 
+echo "Scribe rsync container version: ${version:-unknown}"
+
 # Allow source's key to access, but restrict what it can do.
 mkdir -p ~/.ssh
 chmod 700 ~/.ssh

--- a/mover-rsync/source.sh
+++ b/mover-rsync/source.sh
@@ -2,6 +2,8 @@
 
 set -e -o pipefail
 
+echo "Scribe rsync container version: ${version:-unknown}"
+
 # Ensure we have connection info for the destination
 DESTINATION_PORT="${DESTINATION_PORT:-22}"
 if [[ -z "$DESTINATION_ADDRESS" ]]; then


### PR DESCRIPTION
**Describe what this PR does**
- Adds version info to operator & movers (they print their version at startup)
- Adds ability to override the container image for rclone (rsync had this already) via cli option

**Is there anything that requires special attention?**
The original #64 was slightly different, asking to embed the release tag (and use that) else fallback to `latest`. Upon more thinking, this seems over complicated to implement (what's a "pure" version that should use the tag vs latest?). Instead, this just uses latest by default, and the Helm chart or CSV (for operatorhub) will be expected to provide the proper cli option to the operator so that it uses the correct tag for the movers. In the case of Helm, this is easy by defaulting to the appversion, but will require a bit more care when creating the CSV.

**Related issues:**
Fixes #64 
