### PR TITLE
currently rclone cannot be paused

### DIFF
--- a/controllers/replicationdestination_controller.go
+++ b/controllers/replicationdestination_controller.go
@@ -470,6 +470,13 @@ func (r *rcloneDestReconciler) ensureJob(l logr.Logger) (bool, error) {
 		}
 		backoffLimit := int32(2)
 		r.job.Spec.BackoffLimit = &backoffLimit
+		if r.Instance.Spec.Paused {
+			parallelism := int32(0)
+			r.job.Spec.Parallelism = &parallelism
+		} else {
+			parallelism := int32(1)
+			r.job.Spec.Parallelism = &parallelism
+		}
 		if len(r.job.Spec.Template.Spec.Containers) != 1 {
 			r.job.Spec.Template.Spec.Containers = []corev1.Container{{}}
 		}

--- a/controllers/replicationsource_controller.go
+++ b/controllers/replicationsource_controller.go
@@ -294,6 +294,13 @@ func (r *rcloneSrcReconciler) ensureJob(l logr.Logger) (bool, error) {
 		}
 		backoffLimit := int32(2)
 		r.job.Spec.BackoffLimit = &backoffLimit
+		if r.Instance.Spec.Paused {
+			parallelism := int32(0)
+			r.job.Spec.Parallelism = &parallelism
+		} else {
+			parallelism := int32(1)
+			r.job.Spec.Parallelism = &parallelism
+		}
 		if len(r.job.Spec.Template.Spec.Containers) != 1 {
 			r.job.Spec.Template.Spec.Containers = []corev1.Container{{}}
 		}


### PR DESCRIPTION
Signed-off-by: Ryan Cook <rcook@redhat.com>

**Describe what this PR does**
This PR adds pause func to rclone. This can be set in the event a destination or source does not want data to be sent

**Is there anything that requires special attention?**
No

**Related issues:**
No
