### PR TITLE
Add helm chart

### DIFF
--- a/.ci-scripts/pre-commit.sh
+++ b/.ci-scripts/pre-commit.sh
@@ -54,4 +54,7 @@ run_check '.*\.(ba)?sh' shellcheck
 # Install via: pip install yamllint
 run_check '.*\.ya?ml' yamllint -s -c "${scriptdir}/yamlconfig.yaml"
 
+# CRDs in the Helm chart must match generated CRDs
+diff -qr config/crd/bases helm/scribe/crds
+
 echo "ALL OK."

--- a/.ci-scripts/yamlconfig.yaml
+++ b/.ci-scripts/yamlconfig.yaml
@@ -5,6 +5,7 @@ extends: default
 ignore: |
   config/**
   hack/crds/*
+  helm/scribe/**
 rules:
   indentation:
     indent-sequences: consistent

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -122,8 +122,8 @@ jobs:
       matrix:
         # There must be kindest/node images for these versions
         # See: https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
-        # KUBERNETES_VERSIONS: ["1.16.9", "1.17.5", "1.18.8", "1.19.0"]
-        KUBERNETES_VERSIONS: ["1.20.0"]
+        # Or: skopeo list-tags docker://kindest/node
+        KUBERNETES_VERSIONS: ["1.20.2"]
     env:
       KUBECONFIG: /tmp/kubeconfig
       KUBERNETES_VERSION: ${{ matrix.KUBERNETES_VERSIONS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+ARG VERSION="(unknown)"
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager -ldflags "-X=main.scribeVersion=${VERSION}" main.go
 
 # Final container
 FROM centos:8

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ generate: controller-gen
 # Build the docker image
 .PHONY: docker-build
 docker-build:
-	docker build . -t ${IMAGE}
+	docker build --build-arg "VERSION=$(VERSION)" . -t ${IMAGE}
 
 # Push the docker image
 .PHONY: docker-push

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,15 @@ all: manager manifests
 # Run tests
 .PHONY: test
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: generate manifests golangci-lint ginkgo
+test: generate manifests golangci-lint ginkgo helm-lint
 	$(GOLANGCILINT) run ./...
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); ginkgo $(TEST_ARGS) ./...
+
+.PHONY: helm-lint
+helm-lint: helm
+	cd helm && $(HELM) lint scribe
 
 # Build manager binary
 .PHONY: manager

--- a/hack/run-in-kind.sh
+++ b/hack/run-in-kind.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+set -e -o pipefail
+
+# cd to top dir
+scriptdir="$(dirname "$(realpath "$0")")"
+cd "$scriptdir/.."
+
+# Build the container images
+make docker-build
+make -C mover-rclone image
+make -C mover-rsync image
+
+# Load the images into kind
+# We are using a special tag that should never be pushed to a repo so that it's
+# obvious if we try to run a container other than these intended ones.
+KIND_TAG=local-build
+IMAGES=("quay.io/backube/scribe" "quay.io/backube/scribe-mover-rclone" "quay.io/backube/scribe-mover-rsync")
+for i in "${IMAGES[@]}"; do
+    docker tag "${i}:latest" "${i}:${KIND_TAG}"
+    kind load docker-image "${i}:${KIND_TAG}"
+done
+
+helm install --create-namespace -n scribe-system \
+    --set image.tag="${KIND_TAG}" \
+    --set rclone.tag="${KIND_TAG}" \
+    --set rsync.tag="${KIND_TAG}" \
+    scribe ./helm/scribe

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 # Possible versions:
 # https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
 # skopeo inspect docker://kindest/node:v1.17.0 | jq .RepoTags
-KUBE_VERSION="${1:-1.20.0}"
+KUBE_VERSION="${1:-1.20.2}"
 
 # Determine the Kube minor version
 [[ "${KUBE_VERSION}" =~ ^[0-9]+\.([0-9]+) ]] && KUBE_MINOR="${BASH_REMATCH[1]}" || exit 1

--- a/helm/scribe/.helmignore
+++ b/helm/scribe/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/scribe/Chart.yaml
+++ b/helm/scribe/Chart.yaml
@@ -1,0 +1,53 @@
+apiVersion: v2
+name: scribe
+type: application
+description: Asynchronous data replication for Kubernetes
+home: https://scribe-replication.readthedocs.io/
+icon: https://raw.githubusercontent.com/backube/scribe/master/docs/media/scribe.svg?sanitize=true
+sources:
+  - https://github.com/backube/scribe
+maintainers:
+  - name: John Strunk
+    email: jstrunk@redhat.com
+    url: https://github.com/JohnStrunk
+keywords:
+  - csi
+  - data
+  - disaster recovery
+  - replication
+  - storage
+annotations:
+  # Changelog for current chart & app version
+  # Prefix w/ Added/Changed/Deprecated/Fixed/Removed/Security
+  artifacthub.io/changes: |
+    - Added: Initial release
+  artifacthub.io/crds: |
+    - kind: ReplicationDestination
+      version: v1alpha1
+      name: replicationdestination.scribe.backube
+      displayName: Replication destination
+      description: Defines the destination of a replicated volume
+    - kind: ReplicationSource
+      version: v1alpha1
+      name: replicationsource.scribe.backube
+      displayName: Replication source
+      description: Defines the source of a replicated volume
+  artifacthub.io/license: AGPL-3.0-or-later
+  artifacthub.io/operator: "true"
+  artifacthub.io/operatorCapabilities: Basic Install
+
+# We require beta-level CSI snapshots (1.17+)
+# Adding "-0" at the end of the version string permits pre-release kube versions
+# to match. See https://github.com/helm/helm/issues/6190
+kubeVersion: "^1.17.0-0"
+
+# This is the chart version. This version number should be incremented each time
+# you make changes to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: "0.1.0"
+
+# This is the version number of the application being deployed. This version
+# number should be incremented each time you make changes to the application.
+# Versions are not expected to follow Semantic Versioning. They should reflect
+# the version the application is using. It is recommended to use it with quotes.
+appVersion: "0.1.0"

--- a/helm/scribe/README.md
+++ b/helm/scribe/README.md
@@ -1,0 +1,116 @@
+# Scribe
+
+Asynchronous volume replication for Kubernetes CSI storage
+
+## About this operator
+
+Scribe is a Kubernetes operator that performs asynchronous replication of
+persistent volumes within, or across, clusters. Scribe supports replication in a
+storage system independent manner. This means replication can be used with
+storage systems that do not support replication natively. Data can also be
+replicated across different types (and vendors) of storage.
+
+Scribe supports both 1:1 replication relationships as well as 1:many
+relationships. This provides the flexibility to support use cases such as
+disaster recovery, mirroring data to a test environment, or data distribution to
+a set of remote clusters from a central site.
+
+### How it works
+
+A ReplicationSource object in the same Namespace as the volume (PVC) to be
+replicated determines how, when, and to where the data should be replicated.
+
+A ReplicationDestination object at the destination serves as the target for the
+replicated data.
+
+Scribe has several replication methods than can be used to replicate data.
+
+- Rclone-based replication for 1:many data distribution  
+  With this replication method, data is replicated from the source to an
+  intermediate cloud storage service ([supported by
+  Rclone](https://rclone.org/#providers)). The destination(s) then retrieve the
+  data from this intermediate location.
+- Rsync-based replication for 1:1 data replication  
+  This replication method is designed to replicate data directly to a remote
+  location. It uses [Rsync](https://rsync.samba.org/) over an ssh connection to
+  securely and efficiently transfer data.
+
+**Please see the [📖 full documentation
+📖](https://scribe-replication.readthedocs.io/) for more details.**
+
+## Requirements
+
+- Kubernetes >= 1.17
+- The Kubernetes snapshot controller must be installed on the cluster, whether
+  or not clones & snapshots are used.
+- CSI-based storage driver that supports snapshots and/or clones is recommended,
+  but not required
+
+## Installation
+
+Scribe is a cluster-level operator. A single instance of the operator will
+provide replication capabilities to all namespaces in the cluster.  
+**Running more than one instance of Scribe at a time is not supported.**
+
+```console
+$ helm install --create-namespace --namespace scribe-system scribe backube/scribe
+
+NAME: scribe
+LAST DEPLOYED: Thu Jan 28 13:52:18 2021
+NAMESPACE: scribe-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
+NOTES:
+
+The Scribe operator has been installed into the scribe-system namespace.
+
+Please see https://scribe-replication.readthedocs.org for documentation.
+```
+
+## Configuration
+
+The following parameters in the chart can be configured, either by using `--set`
+on the command line or via a custom `values.yaml` file.
+
+- `replicaCount`: `1`
+  - The number of replicas of the operator to run. Only one is active at a time,
+    controlled via leader election.
+- `image.repository`: `quay.io/backube/scribe`
+  - The container image of the Scribe operator
+- `image.pullPolicy`: `IfNotPresent`
+  - The image pull policy to apply to the operator's image
+- `image.tag`: (current appVersion)
+  - The tag to use when retrieving the operator image. This defaults to the tag
+    for the current application version associated with this chart release.
+- `rclone.repository`: `quay.io/backube/scribe-mover-rclone`
+  - The container image for Scribe's rclone-based data mover
+- `rclone.tag`: (current appVersion)
+  - The tag to use for the rclone-based data mover
+- `rsync.repository`: `quay.io/backube/scribe-mover-rsync`
+  - The container image for Scribe's rsync-based data mover
+- `rsync.tag`: (current appVersion)
+  - The tag to use for the rsync-based data mover
+- `imagePullSecrets`: none
+  - May be set if pull secret(s) are needed to retrieve the operator image
+- `serviceAccount.create`: `true`
+  - Whether to create the ServiceAccount for the operator
+- `serviceAccount.annotations`: none
+  - Annotations to add to the operator's service account
+- `serviceAccount.name`: none
+  - Override the name of the operator's ServiceAccount
+- `podSecurityContext`: none
+  - Allows setting the security context for the operator pod
+- `podAnnotations`: none
+  - Annotations to add to the operator's pod
+- `securityContext`: none
+  - Allows setting the operator container's security context
+- `resources`: requests 100m CPU and 20Mi memory; limits 100m CPU and 300Mi
+  memory
+  - Allows overriding the resource requests/limits for the operator pod
+- `nodeSelector`: none
+  - Allows applying a node selector to the operator pod
+- `tolerations`: none
+  - Allows applying tolerations to the operator pod
+- `affinity`: none
+  - Allows setting the operator pod's affinity

--- a/helm/scribe/crds/scribe.backube_replicationdestinations.yaml
+++ b/helm/scribe/crds/scribe.backube_replicationdestinations.yaml
@@ -1,0 +1,324 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: replicationdestinations.scribe.backube
+spec:
+  group: scribe.backube
+  names:
+    kind: ReplicationDestination
+    listKind: ReplicationDestinationList
+    plural: replicationdestinations
+    singular: replicationdestination
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - format: date-time
+      jsonPath: .status.lastSyncTime
+      name: Last sync
+      type: string
+    - jsonPath: .status.lastSyncDuration
+      name: Duration
+      type: string
+    - format: date-time
+      jsonPath: .status.nextSyncTime
+      name: Next sync
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ReplicationDestination defines the destination for a replicated
+          volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the ReplicationDestination,
+              including the replication method to use and its configuration.
+            properties:
+              external:
+                description: external defines the configuration when using an external
+                  replication provider.
+                properties:
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    description: parameters are provider-specific key/value configuration
+                      parameters. For more information, please see the documentation
+                      of the specific replication provider being used.
+                    type: object
+                  provider:
+                    description: 'provider is the name of the external replication
+                      provider. The name should be of the form: domain.com/provider.'
+                    type: string
+                type: object
+              paused:
+                description: paused can be used to temporarily stop replication. Defaults
+                  to "false".
+                type: boolean
+              rclone:
+                description: rclone defines the configuration when using Rclone-based
+                  replication.
+                properties:
+                  accessModes:
+                    description: accessModes specifies the access modes for the destination
+                      volume.
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                  capacity:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: capacity is the size of the destination volume to
+                      create.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  copyMethod:
+                    description: copyMethod describes how a point-in-time (PiT) image
+                      of the destination volume should be created.
+                    enum:
+                    - None
+                    - Clone
+                    - Snapshot
+                    type: string
+                  destinationPVC:
+                    description: destinationPVC is a PVC to use as the transfer destination
+                      instead of automatically provisioning one. Either this field
+                      or both capacity and accessModes must be specified.
+                    type: string
+                  rcloneConfig:
+                    description: RcloneConfig is the rclone secret name
+                    type: string
+                  rcloneConfigSection:
+                    description: RcloneConfigSection is the section in rclone_config
+                      file to use for the current job.
+                    type: string
+                  rcloneDestPath:
+                    description: RcloneDestPath is the remote path to sync to.
+                    type: string
+                  storageClassName:
+                    description: storageClassName can be used to specify the StorageClass
+                      of the destination volume. If not set, the default StorageClass
+                      will be used.
+                    type: string
+                  volumeSnapshotClassName:
+                    description: volumeSnapshotClassName can be used to specify the
+                      VSC to be used if copyMethod is Snapshot. If not set, the default
+                      VSC is used.
+                    type: string
+                type: object
+              rsync:
+                description: rsync defines the configuration when using Rsync-based
+                  replication.
+                properties:
+                  accessModes:
+                    description: accessModes specifies the access modes for the destination
+                      volume.
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                  address:
+                    description: address is the remote address to connect to for replication.
+                    type: string
+                  capacity:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: capacity is the size of the destination volume to
+                      create.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  copyMethod:
+                    description: copyMethod describes how a point-in-time (PiT) image
+                      of the destination volume should be created.
+                    enum:
+                    - None
+                    - Clone
+                    - Snapshot
+                    type: string
+                  destinationPVC:
+                    description: destinationPVC is a PVC to use as the transfer destination
+                      instead of automatically provisioning one. Either this field
+                      or both capacity and accessModes must be specified.
+                    type: string
+                  path:
+                    description: path is the remote path to rsync from. Defaults to
+                      "/"
+                    type: string
+                  port:
+                    description: port is the SSH port to connect to for replication.
+                      Defaults to 22.
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
+                  serviceType:
+                    description: serviceType determines the Service type that will
+                      be created for incoming SSH connections.
+                    type: string
+                  sshKeys:
+                    description: sshKeys is the name of a Secret that contains the
+                      SSH keys to be used for authentication. If not provided, the
+                      keys will be generated.
+                    type: string
+                  sshUser:
+                    description: sshUser is the username for outgoing SSH connections.
+                      Defaults to "root".
+                    type: string
+                  storageClassName:
+                    description: storageClassName can be used to specify the StorageClass
+                      of the destination volume. If not set, the default StorageClass
+                      will be used.
+                    type: string
+                  volumeSnapshotClassName:
+                    description: volumeSnapshotClassName can be used to specify the
+                      VSC to be used if copyMethod is Snapshot. If not set, the default
+                      VSC is used.
+                    type: string
+                type: object
+              trigger:
+                description: trigger determines if/when the destination should attempt
+                  to synchronize data with the source.
+                properties:
+                  schedule:
+                    description: schedule is a cronspec (https://en.wikipedia.org/wiki/Cron#Overview)
+                      that can be used to schedule replication to occur at regular,
+                      time-based intervals.
+                    pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
+                    type: string
+                type: object
+            type: object
+          status:
+            description: status is the observed state of the ReplicationDestination
+              as determined by the controller.
+            properties:
+              conditions:
+                description: conditions represent the latest available observations
+                  of the destination's state.
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              external:
+                additionalProperties:
+                  type: string
+                description: external contains provider-specific status information.
+                  For more details, please see the documentation of the specific replication
+                  provider being used.
+                type: object
+              lastSyncDuration:
+                description: lastSyncDuration is the amount of time required to send
+                  the most recent update.
+                type: string
+              lastSyncTime:
+                description: lastSyncTime is the time of the most recent successful
+                  synchronization.
+                format: date-time
+                type: string
+              latestImage:
+                description: latestImage in the object holding the most recent consistent
+                  replicated image.
+                properties:
+                  apiGroup:
+                    description: APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in
+                      the core API group. For any other third-party types, APIGroup
+                      is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              nextSyncTime:
+                description: nextSyncTime is the time when the next volume synchronization
+                  is scheduled to start (for schedule-based synchronization).
+                format: date-time
+                type: string
+              rsync:
+                description: rsync contains status information for Rsync-based replication.
+                properties:
+                  address:
+                    description: address is the address to connect to for incoming
+                      SSH replication connections.
+                    type: string
+                  port:
+                    description: port is the SSH port to connect to for incoming SSH
+                      replication connections.
+                    format: int32
+                    type: integer
+                  sshKeys:
+                    description: sshKeys is the name of a Secret that contains the
+                      SSH keys to be used for authentication. If not provided in .spec.rsync.sshKeys,
+                      SSH keys will be generated and the appropriate keys for the
+                      remote side will be placed here.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm/scribe/crds/scribe.backube_replicationsources.yaml
+++ b/helm/scribe/crds/scribe.backube_replicationsources.yaml
@@ -1,0 +1,298 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: replicationsources.scribe.backube
+spec:
+  group: scribe.backube
+  names:
+    kind: ReplicationSource
+    listKind: ReplicationSourceList
+    plural: replicationsources
+    singular: replicationsource
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.sourcePVC
+      name: Source
+      type: string
+    - format: date-time
+      jsonPath: .status.lastSyncTime
+      name: Last sync
+      type: string
+    - jsonPath: .status.lastSyncDuration
+      name: Duration
+      type: string
+    - format: date-time
+      jsonPath: .status.nextSyncTime
+      name: Next sync
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ReplicationSource defines the source for a replicated volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the ReplicationSource, including
+              the replication method to use and its configuration.
+            properties:
+              external:
+                description: external defines the configuration when using an external
+                  replication provider.
+                properties:
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    description: parameters are provider-specific key/value configuration
+                      parameters. For more information, please see the documentation
+                      of the specific replication provider being used.
+                    type: object
+                  provider:
+                    description: 'provider is the name of the external replication
+                      provider. The name should be of the form: domain.com/provider.'
+                    type: string
+                type: object
+              paused:
+                description: paused can be used to temporarily stop replication. Defaults
+                  to "false".
+                type: boolean
+              rclone:
+                description: rclone defines the configuration when using Rclone-based
+                  replication.
+                properties:
+                  accessModes:
+                    description: accessModes can be used to override the accessModes
+                      of the PiT image.
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                  capacity:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: capacity can be used to override the capacity of
+                      the PiT image.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  copyMethod:
+                    description: copyMethod describes how a point-in-time (PiT) image
+                      of the source volume should be created.
+                    enum:
+                    - None
+                    - Clone
+                    - Snapshot
+                    type: string
+                  rcloneConfig:
+                    description: RcloneConfig is the rclone secret name
+                    type: string
+                  rcloneConfigSection:
+                    description: RcloneConfigSection is the section in rclone_config
+                      file to use for the current job.
+                    type: string
+                  rcloneDestPath:
+                    description: RcloneDestPath is the remote path to sync to.
+                    type: string
+                  storageClassName:
+                    description: storageClassName can be used to override the StorageClass
+                      of the PiT image.
+                    type: string
+                  volumeSnapshotClassName:
+                    description: volumeSnapshotClassName can be used to specify the
+                      VSC to be used if copyMethod is Snapshot. If not set, the default
+                      VSC is used.
+                    type: string
+                type: object
+              rsync:
+                description: rsync defines the configuration when using Rsync-based
+                  replication.
+                properties:
+                  accessModes:
+                    description: accessModes can be used to override the accessModes
+                      of the PiT image.
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                  address:
+                    description: address is the remote address to connect to for replication.
+                    type: string
+                  capacity:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: capacity can be used to override the capacity of
+                      the PiT image.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  copyMethod:
+                    description: copyMethod describes how a point-in-time (PiT) image
+                      of the source volume should be created.
+                    enum:
+                    - None
+                    - Clone
+                    - Snapshot
+                    type: string
+                  path:
+                    description: path is the remote path to rsync to. Defaults to
+                      "/"
+                    type: string
+                  port:
+                    description: port is the SSH port to connect to for replication.
+                      Defaults to 22.
+                    format: int32
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
+                  serviceType:
+                    description: serviceType determines the Service type that will
+                      be created for incoming SSH connections.
+                    type: string
+                  sshKeys:
+                    description: sshKeys is the name of a Secret that contains the
+                      SSH keys to be used for authentication. If not provided, the
+                      keys will be generated.
+                    type: string
+                  sshUser:
+                    description: sshUser is the username for outgoing SSH connections.
+                      Defaults to "root".
+                    type: string
+                  storageClassName:
+                    description: storageClassName can be used to override the StorageClass
+                      of the PiT image.
+                    type: string
+                  volumeSnapshotClassName:
+                    description: volumeSnapshotClassName can be used to specify the
+                      VSC to be used if copyMethod is Snapshot. If not set, the default
+                      VSC is used.
+                    type: string
+                type: object
+              sourcePVC:
+                description: sourcePVC is the name of the PersistentVolumeClaim (PVC)
+                  to replicate.
+                type: string
+              trigger:
+                description: trigger determines when the latest state of the volume
+                  will be captured (and potentially replicated to the destination).
+                properties:
+                  schedule:
+                    description: schedule is a cronspec (https://en.wikipedia.org/wiki/Cron#Overview)
+                      that can be used to schedule replication to occur at regular,
+                      time-based intervals.
+                    pattern: ^(\d+|\*)(/\d+)?(\s+(\d+|\*)(/\d+)?){4}$
+                    type: string
+                type: object
+            type: object
+          status:
+            description: status is the observed state of the ReplicationSource as
+              determined by the controller.
+            properties:
+              conditions:
+                description: conditions represent the latest available observations
+                  of the source's state.
+                items:
+                  description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              external:
+                additionalProperties:
+                  type: string
+                description: external contains provider-specific status information.
+                  For more details, please see the documentation of the specific replication
+                  provider being used.
+                type: object
+              lastSyncDuration:
+                description: lastSyncDuration is the amount of time required to send
+                  the most recent update.
+                type: string
+              lastSyncTime:
+                description: lastSyncTime is the time of the most recent successful
+                  synchronization.
+                format: date-time
+                type: string
+              nextSyncTime:
+                description: nextSyncTime is the time when the next volume synchronization
+                  is scheduled to start (for schedule-based synchronization).
+                format: date-time
+                type: string
+              rsync:
+                description: rsync contains status information for Rsync-based replication.
+                properties:
+                  address:
+                    description: address is the address to connect to for incoming
+                      SSH replication connections.
+                    type: string
+                  port:
+                    description: port is the SSH port to connect to for incoming SSH
+                      replication connections.
+                    format: int32
+                    type: integer
+                  sshKeys:
+                    description: sshKeys is the name of a Secret that contains the
+                      SSH keys to be used for authentication. If not provided in .spec.rsync.sshKeys,
+                      SSH keys will be generated and the appropriate keys for the
+                      remote side will be placed here.
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm/scribe/templates/NOTES.txt
+++ b/helm/scribe/templates/NOTES.txt
@@ -1,0 +1,5 @@
+
+The Scribe operator has been installed into the {{ .Release.Namespace }}
+namespace.
+
+Please see https://scribe-replication.readthedocs.org for documentation.

--- a/helm/scribe/templates/SCC-mover.yaml
+++ b/helm/scribe/templates/SCC-mover.yaml
@@ -1,0 +1,36 @@
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "scribe.fullname" . }}-mover
+  labels:
+    {{- include "scribe.labels" . | nindent 4 }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities:
+  - AUDIT_WRITE
+  - SYS_CHROOT
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+{{- end }}

--- a/helm/scribe/templates/_helpers.tpl
+++ b/helm/scribe/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "scribe.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "scribe.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "scribe.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "scribe.labels" -}}
+helm.sh/chart: {{ include "scribe.chart" . }}
+{{ include "scribe.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "scribe.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "scribe.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "scribe.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "scribe.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/scribe/templates/clusterrole-manager.yaml
+++ b/helm/scribe/templates/clusterrole-manager.yaml
@@ -1,0 +1,175 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "scribe.fullname" . }}-manager
+  labels:
+    {{- include "scribe.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scribe.backube
+  resources:
+  - replicationdestinations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scribe.backube
+  resources:
+  - replicationdestinations/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scribe.backube
+  resources:
+  - replicationdestinations/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - scribe.backube
+  resources:
+  - replicationsources
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scribe.backube
+  resources:
+  - replicationsources/finalizers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - scribe.backube
+  resources:
+  - replicationsources/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - {{ include "scribe.fullname" . }}-mover
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/helm/scribe/templates/clusterrole-metrics-reader.yaml
+++ b/helm/scribe/templates/clusterrole-metrics-reader.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "scribe.fullname" . }}-metrics-reader
+  labels:
+    {{- include "scribe.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/helm/scribe/templates/clusterrole-proxy-role.yaml
+++ b/helm/scribe/templates/clusterrole-proxy-role.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "scribe.fullname" . }}-proxy
+  labels:
+    {{- include "scribe.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/helm/scribe/templates/clusterrolebinding-manager.yaml
+++ b/helm/scribe/templates/clusterrolebinding-manager.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "scribe.fullname" . }}-manager
+  labels:
+    {{- include "scribe.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "scribe.fullname" . }}-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ include "scribe.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/scribe/templates/clusterrolebinding-proxy.yaml
+++ b/helm/scribe/templates/clusterrolebinding-proxy.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "scribe.fullname" . }}-proxy
+  labels:
+    {{- include "scribe.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "scribe.fullname" . }}-proxy
+subjects:
+- kind: ServiceAccount
+  name: {{ include "scribe.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/scribe/templates/deployment-controller.yaml
+++ b/helm/scribe/templates/deployment-controller.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "scribe.fullname" . }}
+  labels:
+    control-plane: {{ include "scribe.fullname" . }}-controller
+    {{- include "scribe.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      control-plane: {{ include "scribe.fullname" . }}-controller
+      {{- include "scribe.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        control-plane: {{ include "scribe.fullname" . }}-controller
+        {{- include "scribe.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "scribe.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: kube-rbac-proxy
+          args:
+            - --secure-listen-address=0.0.0.0:8443
+            - --upstream=http://127.0.0.1:8080/
+            - --logtostderr=true
+            - --v=10
+          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+          ports:
+            - containerPort: 8443
+              name: https
+        - name: manager
+          args:
+            - --metrics-addr=127.0.0.1:8080
+            - --enable-leader-election
+            - --rclone-container-image={{ .Values.rclone.repository }}:{{ .Values.rclone.tag | default .Chart.AppVersion }}
+            - --rsync-container-image={{ .Values.rsync.repository }}:{{ .Values.rsync.tag | default .Chart.AppVersion }}
+          command:
+            - /manager
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 10
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/scribe/templates/role-leader-election.yaml
+++ b/helm/scribe/templates/role-leader-election.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "scribe.fullname" . }}-leader-election
+  labels:
+    {{- include "scribe.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/helm/scribe/templates/rolebinding-leader-election.yaml
+++ b/helm/scribe/templates/rolebinding-leader-election.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "scribe.fullname" . }}-leader-election
+  labels:
+    {{- include "scribe.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "scribe.fullname" . }}-leader-election
+subjects:
+- kind: ServiceAccount
+  name: {{ include "scribe.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/scribe/templates/service-metrics.yaml
+++ b/helm/scribe/templates/service-metrics.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "scribe.fullname" . }}-metrics-service
+  labels:
+    control-plane: {{ include "scribe.fullname" . }}-controller
+    {{- include "scribe.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    control-plane: {{ include "scribe.fullname" . }}-controller

--- a/helm/scribe/templates/serviceaccount.yaml
+++ b/helm/scribe/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "scribe.serviceAccountName" . }}
+  labels:
+    {{- include "scribe.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/scribe/values.yaml
+++ b/helm/scribe/values.yaml
@@ -1,0 +1,56 @@
+# Default values for scribe.
+replicaCount: 1
+
+image:
+  repository: quay.io/backube/scribe
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+rclone:
+  repository: quay.io/backube/scribe-mover-rclone
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+rsync:
+  repository: quay.io/backube/scribe-mover-rsync
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 300Mi
+  requests:
+    cpu: 100m
+    memory: 20Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
**Describe what this PR does**
This adds a Helm chart that can be used to deploy Scribe.
* The manifests were created based on the `make deploy` and `make deploy-openshift` targets.
* The chart detects the presence of SCCs in the cluster and only inserts the Scribe mover SCC if that CRD is available.
* Also adds `hack/run-in-kind.sh` that uses the Helm chart to deploy your local code to your running kind cluster. Eventually, we'll switch to using this in the CI checks.

**Is there anything that requires special attention?**

**Related issues:**
Fixes #50 