### PR TITLE
error if more than one method provided

### DIFF
--- a/controllers/replicationdestination_controller.go
+++ b/controllers/replicationdestination_controller.go
@@ -20,6 +20,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -99,9 +100,10 @@ func (r *ReplicationDestinationReconciler) Reconcile(req ctrl.Request) (ctrl.Res
 	var result ctrl.Result
 	var err error
 	// Only reconcile if the replication method is internal
-	if inst.Spec.Rsync != nil && inst.Spec.Rclone != nil {
-		logger.Error(err, "Only rclone or rsync can be specified")
-		return ctrl.Result{}, err
+	if inst.Spec.Rsync != nil && inst.Spec.Rclone != nil ||
+		inst.Spec.External != nil && inst.Spec.Rclone != nil ||
+		inst.Spec.Rsync != nil && inst.Spec.External != nil {
+		err = fmt.Errorf("only a single replication method can be provided")
 	} else if inst.Spec.Rsync != nil {
 		result, err = RunRsyncDestReconciler(ctx, inst, r, logger)
 	} else if inst.Spec.Rclone != nil {

--- a/controllers/replicationdestination_controller.go
+++ b/controllers/replicationdestination_controller.go
@@ -74,6 +74,7 @@ type ReplicationDestinationReconciler struct {
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=scribe-mover,verbs=use
 //+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch;create;update;patch;delete
 
+//nolint:funlen
 func (r *ReplicationDestinationReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	logger := r.Log.WithValues("replicationdestination", req.NamespacedName)
@@ -98,7 +99,10 @@ func (r *ReplicationDestinationReconciler) Reconcile(req ctrl.Request) (ctrl.Res
 	var result ctrl.Result
 	var err error
 	// Only reconcile if the replication method is internal
-	if inst.Spec.Rsync != nil {
+	if inst.Spec.Rsync != nil && inst.Spec.Rclone != nil {
+		logger.Error(err, "Only rclone or rsync can be specified")
+		return ctrl.Result{}, err
+	} else if inst.Spec.Rsync != nil {
 		result, err = RunRsyncDestReconciler(ctx, inst, r, logger)
 	} else if inst.Spec.Rclone != nil {
 		result, err = RunRcloneDestReconciler(ctx, inst, r, logger)

--- a/controllers/replicationsource_controller.go
+++ b/controllers/replicationsource_controller.go
@@ -66,6 +66,7 @@ type ReplicationSourceReconciler struct {
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=scribe-mover,verbs=use
 //+kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch;create;update;patch;delete
 
+//nolint:funlen
 func (r *ReplicationSourceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	logger := r.Log.WithValues("replicationsource", req.NamespacedName)
@@ -86,7 +87,10 @@ func (r *ReplicationSourceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, 
 
 	var result ctrl.Result
 	var err error
-	if inst.Spec.Rsync != nil {
+	if inst.Spec.Rsync != nil && inst.Spec.Rclone != nil {
+		logger.Error(err, "Only rclone or rsync can be specified")
+		return ctrl.Result{}, err
+	} else if inst.Spec.Rsync != nil {
 		result, err = RunRsyncSrcReconciler(ctx, inst, r, logger)
 	} else if inst.Spec.Rclone != nil {
 		result, err = RunRcloneSrcReconciler(ctx, inst, r, logger)

--- a/controllers/replicationsource_controller.go
+++ b/controllers/replicationsource_controller.go
@@ -20,6 +20,7 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -87,9 +88,10 @@ func (r *ReplicationSourceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, 
 
 	var result ctrl.Result
 	var err error
-	if inst.Spec.Rsync != nil && inst.Spec.Rclone != nil {
-		logger.Error(err, "Only rclone or rsync can be specified")
-		return ctrl.Result{}, err
+	if inst.Spec.Rsync != nil && inst.Spec.Rclone != nil ||
+		inst.Spec.External != nil && inst.Spec.Rclone != nil ||
+		inst.Spec.Rsync != nil && inst.Spec.External != nil {
+		err = fmt.Errorf("only a single replication method can be provided")
 	} else if inst.Spec.Rsync != nil {
 		result, err = RunRsyncSrcReconciler(ctx, inst, r, logger)
 	} else if inst.Spec.Rclone != nil {


### PR DESCRIPTION
Signed-off-by: Ryan Cook <rcook@redhat.com>

**Describe what this PR does**
Forces only 1 method to be provided. If more than one method is provided error is written to log and no pod created

**Is there anything that requires special attention?**
N/A

**Related issues:**
#80 
