### PR TITLE
Switch CI to use Helm chart

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.venv
+bin
+testbin

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -138,6 +138,9 @@ jobs:
           kubectl version --short --client
           kubectl version --short --client | grep -q ${KUBERNETES_VERSION}
 
+      - name: Install helm
+        run: make helm
+
       - name: Install kind
         run: |
           curl -L -o kind https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64
@@ -159,7 +162,8 @@ jobs:
         run: |
           docker load -i /tmp/image.tar
           docker inspect ${OPERATOR_IMAGE}
-          kind load docker-image "${OPERATOR_IMAGE}"
+          docker tag ${OPERATOR_IMAGE} ${OPERATOR_IMAGE}:ci-build
+          kind load docker-image "${OPERATOR_IMAGE}:ci-build"
 
       - name: Load rclone container artifact
         uses: actions/download-artifact@v1
@@ -171,7 +175,8 @@ jobs:
         run: |
           docker load -i /tmp/image.tar
           docker inspect ${RCLONE_IMAGE}
-          kind load docker-image "${RCLONE_IMAGE}"
+          docker tag ${RCLONE_IMAGE} ${RCLONE_IMAGE}:ci-build
+          kind load docker-image "${RCLONE_IMAGE}:ci-build"
 
       - name: Load rsync container artifact
         uses: actions/download-artifact@v1
@@ -183,12 +188,16 @@ jobs:
         run: |
           docker load -i /tmp/image.tar
           docker inspect ${RSYNC_IMAGE}
-          kind load docker-image "${RSYNC_IMAGE}"
+          docker tag ${RSYNC_IMAGE} ${RSYNC_IMAGE}:ci-build
+          kind load docker-image "${RSYNC_IMAGE}:ci-build"
 
-      # TODO: Replace this with `helm install` once we have a chart
       - name: Start operator
         run: |
-          make deploy
+          helm install --create-namespace -n scribe-system \
+              --set image.tag=ci-build \
+              --set rclone.tag=ci-build \
+              --set rsync.tag=ci-build \
+              scribe ./helm/scribe
 
       - name: Run e2e tests
         run: make test-e2e

--- a/hack/run-minio.sh
+++ b/hack/run-minio.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+set -e -o pipefail
+
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+
+helm install --create-namespace -n minio \
+    --set accessKey.password=access \
+    --set secretKey.password=password \
+    --set securityContext.enabled=false \
+    --set defaultBuckets=mybucket \
+    minio bitnami/minio

--- a/test-kuttl/e2e/operator-running/00-assert.yaml
+++ b/test-kuttl/e2e/operator-running/00-assert.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: scribe-controller-manager
+  name: scribe
   namespace: scribe-system
 status:
   readyReplicas: 1


### PR DESCRIPTION
**Describe what this PR does**
Now that the Helm chart is merged, use that chart to install Scribe for the kuttl e2e tests

**Is there anything that requires special attention?**
The Helm chart creates a Deployment that is named `scribe` instead of `scribe-controller-manager`. This necessitated a change to the kuttl test.

This also adds the `run-minio.sh` script that I've had sitting around. It may be useful for adding e2e kuttl test for rclone. It's not currently used.

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
