### PR TITLE
Rework next sync calculation

### DIFF
--- a/controllers/replicationsource_controller.go
+++ b/controllers/replicationsource_controller.go
@@ -149,19 +149,9 @@ func (r *ReplicationSourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// Check schedule to see if it's time to sync
-func awaitNextSyncSource(rs *scribev1alpha1.ReplicationSource, logger logr.Logger) (bool, error) {
-	if cont, err := ensureNextSyncValidSource(rs, logger); !cont || err != nil {
-		return cont, err
-	}
-	if !rs.Status.NextSyncTime.IsZero() && rs.Status.NextSyncTime.Time.After(time.Now()) {
-		return false, nil
-	}
-	return true, nil
-}
-
-// Set the next sync time accd to the schedule
+//nolint:dupl
 func updateNextSyncSource(rs *scribev1alpha1.ReplicationSource, logger logr.Logger) (bool, error) {
+	// if there's a schedule
 	if rs.Spec.Trigger != nil && rs.Spec.Trigger.Schedule != nil {
 		parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
 		schedule, err := parser.Parse(*rs.Spec.Trigger.Schedule)
@@ -169,22 +159,37 @@ func updateNextSyncSource(rs *scribev1alpha1.ReplicationSource, logger logr.Logg
 			logger.Error(err, "error parsing schedule", "cronspec", rs.Spec.Trigger.Schedule)
 			return false, err
 		}
-		next := schedule.Next(time.Now())
-		rs.Status.NextSyncTime = &metav1.Time{Time: next}
+
+		// If we've previously completed a sync
+		if rs.Status.LastSyncTime != nil {
+			next := schedule.Next(rs.Status.LastSyncTime.Time)
+			rs.Status.NextSyncTime = &metav1.Time{Time: next}
+		} else { // Never synced before, so we should ASAP
+			rs.Status.NextSyncTime = &metav1.Time{Time: time.Now()}
+		}
+	} else { // No schedule, so there's no "next"
+		rs.Status.NextSyncTime = nil
 	}
+
 	return true, nil
 }
 
-// Make sure the next sync time is valid based on the schedule
-func ensureNextSyncValidSource(rs *scribev1alpha1.ReplicationSource, logger logr.Logger) (bool, error) {
-	if rs.Spec.Trigger != nil && rs.Spec.Trigger.Schedule != nil {
-		if rs.Status.NextSyncTime == nil {
-			return updateNextSyncSource(rs, logger)
-		}
+func awaitNextSyncSource(rs *scribev1alpha1.ReplicationSource, logger logr.Logger) (bool, error) {
+	// Ensure nextSyncTime is correct
+	if cont, err := updateNextSyncSource(rs, logger); !cont || err != nil {
+		return cont, err
+	}
+
+	// If there's no next (no schedule) or we're past the nextSyncTime, we should sync
+	if rs.Status.NextSyncTime.IsZero() || rs.Status.NextSyncTime.Time.Before(time.Now()) {
 		return true, nil
 	}
-	rs.Status.NextSyncTime = nil
-	return true, nil
+	return false, nil
+}
+
+func updateLastSyncSource(rs *scribev1alpha1.ReplicationSource, logger logr.Logger) (bool, error) {
+	rs.Status.LastSyncTime = &metav1.Time{Time: time.Now()}
+	return updateNextSyncSource(rs, logger)
 }
 
 type rsyncSrcReconciler struct {
@@ -203,6 +208,7 @@ type rcloneSrcReconciler struct {
 	job                *batchv1.Job
 }
 
+//nolint:dupl
 func RunRsyncSrcReconciler(ctx context.Context, instance *scribev1alpha1.ReplicationSource,
 	sr *ReplicationSourceReconciler, logger logr.Logger) (ctrl.Result, error) {
 	r := rsyncSrcReconciler{
@@ -225,9 +231,6 @@ func RunRsyncSrcReconciler(ctx context.Context, instance *scribev1alpha1.Replica
 	awaitNextSync := func(l logr.Logger) (bool, error) {
 		return awaitNextSyncSource(r.Instance, l)
 	}
-	updateNextsync := func(l logr.Logger) (bool, error) {
-		return updateNextSyncSource(r.Instance, l)
-	}
 
 	_, err := reconcileBatch(l,
 		awaitNextSync,
@@ -239,7 +242,6 @@ func RunRsyncSrcReconciler(ctx context.Context, instance *scribev1alpha1.Replica
 		r.ensureJob,
 		r.cleanupJob,
 		r.CleanupPVC,
-		updateNextsync,
 	)
 	return ctrl.Result{}, err
 }
@@ -262,9 +264,6 @@ func RunRcloneSrcReconciler(ctx context.Context, instance *scribev1alpha1.Replic
 	awaitNextSync := func(l logr.Logger) (bool, error) {
 		return awaitNextSyncSource(r.Instance, l)
 	}
-	updateNextsync := func(l logr.Logger) (bool, error) {
-		return updateNextSyncSource(r.Instance, l)
-	}
 
 	_, err := reconcileBatch(l,
 		awaitNextSync,
@@ -275,7 +274,6 @@ func RunRcloneSrcReconciler(ctx context.Context, instance *scribev1alpha1.Replic
 		r.ensureJob,
 		r.cleanupJob,
 		r.CleanupPVC,
-		updateNextsync,
 	)
 	return ctrl.Result{}, err
 }
@@ -602,7 +600,9 @@ func (r *rsyncSrcReconciler) ensureJob(l logr.Logger) (bool, error) {
 func (r *rsyncSrcReconciler) cleanupJob(l logr.Logger) (bool, error) {
 	logger := l.WithValues("job", r.job)
 	// update time/duration
-	r.Instance.Status.LastSyncTime = &metav1.Time{Time: time.Now()}
+	if _, err := updateLastSyncSource(r.Instance, logger); err != nil {
+		return false, err
+	}
 	if r.job.Status.StartTime != nil {
 		d := r.Instance.Status.LastSyncTime.Sub(r.job.Status.StartTime.Time)
 		r.Instance.Status.LastSyncDuration = &metav1.Duration{Duration: d}
@@ -618,7 +618,9 @@ func (r *rsyncSrcReconciler) cleanupJob(l logr.Logger) (bool, error) {
 func (r *rcloneSrcReconciler) cleanupJob(l logr.Logger) (bool, error) {
 	logger := l.WithValues("job", r.job)
 	// update time/duration
-	r.Instance.Status.LastSyncTime = &metav1.Time{Time: time.Now()}
+	if _, err := updateLastSyncSource(r.Instance, logger); err != nil {
+		return false, err
+	}
 	if r.job.Status.StartTime != nil {
 		d := r.Instance.Status.LastSyncTime.Sub(r.job.Status.StartTime.Time)
 		r.Instance.Status.LastSyncDuration = &metav1.Duration{Duration: d}


### PR DESCRIPTION
**Describe what this PR does**
The previous calculation of the next sync time failed to handle changes to the schedule.
This new implementation bases the calculations on `lastSyncTime` + the schedule. `nextSyncTime` is now really just advisory (i.e., useful to the user, but not used for any internal purposes). On every reconcile, we calculate the correct "next" as "last" + "schedule". This ensures that changes to the schedule are immediately reflected.

Another effect of this re-implementation is that we initiate a sync immediately upon CR creation instead of waiting for the schedule. This seems to be what most users would want.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->
There's a good bit of duplication in the scheduling code (as evidenced by my `//nolint:dupl`). I'd be interested in suggestions on how to fix this. I feel like there's a golang way to fix this, but I just don't know what it is. :crying_cat_face: 

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
Fixes #98 