### PR TITLE
Missing directories

### DIFF
--- a/mover-rclone/active.sh
+++ b/mover-rclone/active.sh
@@ -28,7 +28,7 @@ source)
     ;;
 destination)
     rclone sync "${RCLONE_FLAGS[@]}" "${RCLONE_CONFIG_SECTION}:${RCLONE_DEST_PATH}" "${MOUNT_PATH}" --log-level DEBUG
-    setfacl --restore="${MOUNT_PATH}"/permissons.facl
+    setfacl --restore="${MOUNT_PATH}"/permissons.facl || true
     rm -rf "${MOUNT_PATH}"/permissons.facl
     rc=$?
     ;;


### PR DESCRIPTION
Signed-off-by: Ryan Cook <rcook@redhat.com>

**Describe what this PR does**
Sometimes an empty directory may be at source but not at destination such as lost+found or various cache directories. These are recorded at source but at dest due to how rclone operates they are not uploaded to the object store. We are going to force true on the restore to get around this

**Is there anything that requires special attention?**
I don't know if there is a better resolution for this

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
