### PR TITLE
add cli option for 'scribe-name' to prefix scribe resources

### DIFF
--- a/controllers/replicationdestination_controller.go
+++ b/controllers/replicationdestination_controller.go
@@ -48,6 +48,8 @@ const (
 	DefaultRcloneContainerImage = "quay.io/backube/scribe-mover-rclone:latest"
 	// DefaultResticContainerImage is the default container image name of the restic data mover
 	DefaultResticContainerImage = "quay.io/backube/scribe-mover-restic:latest"
+	// DefaultSCCName is the default name of the scribe security context constraint
+	DefaultSCCName = "scribe-mover"
 )
 
 var (
@@ -57,6 +59,8 @@ var (
 	RcloneContainerImage string
 	// ResticContainerImage is the container image name of the restic data mover
 	ResticContainerImage string
+	// SCCName is the name of the scribe security context constraint
+	SCCName string
 )
 
 // ReplicationDestinationReconciler reconciles a ReplicationDestination object

--- a/controllers/sahandler.go
+++ b/controllers/sahandler.go
@@ -85,7 +85,7 @@ func (d *rsyncSADescription) ensureRole(l logr.Logger) (bool, error) {
 				Resources: []string{"securitycontextconstraints"},
 				// Must match the name of the SCC that is deployed w/ the operator
 				// config/openshift/mover_scc.yaml
-				ResourceNames: []string{"scribe-mover"},
+				ResourceNames: []string{SCCName},
 				Verbs:         []string{"use"},
 			},
 		}

--- a/helm/scribe/README.md
+++ b/helm/scribe/README.md
@@ -55,6 +55,7 @@ provide replication capabilities to all namespaces in the cluster.
 **Running more than one instance of Scribe at a time is not supported.**
 
 ```console
+$ helm repo add backube-helm-charts https://backube.github.io/helm-charts/
 $ helm install --create-namespace --namespace scribe-system scribe backube/scribe
 
 NAME: scribe

--- a/helm/scribe/templates/deployment-controller.yaml
+++ b/helm/scribe/templates/deployment-controller.yaml
@@ -46,6 +46,7 @@ spec:
             - --rclone-container-image={{ .Values.rclone.repository }}:{{ .Values.rclone.tag | default .Chart.AppVersion }}
             - --restic-container-image={{ .Values.restic.repository }}:{{ .Values.restic.tag | default .Chart.AppVersion }}
             - --rsync-container-image={{ .Values.rsync.repository }}:{{ .Values.rsync.tag | default .Chart.AppVersion }}
+            - --scc-name={{ include "scribe.fullname" . }}-mover
           command:
             - /manager
           securityContext:

--- a/main.go
+++ b/main.go
@@ -61,6 +61,8 @@ func main() {
 		controllers.DefaultResticContainerImage, "The container image for the restic data mover")
 	flag.StringVar(&controllers.RsyncContainerImage, "rsync-container-image",
 		controllers.DefaultRsyncContainerImage, "The container image for the rsync data mover")
+	flag.StringVar(&controllers.SCCName, "scc-name",
+		controllers.DefaultSCCName, "The name of the scribe security context constraint")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))


### PR DESCRIPTION
**Describe what this PR does**
provides a cli option `scribe-name` with default "scribe" to prefix scribe resources with (SCC name in this PR) 

**Related issues:**

https://github.com/backube/scribe/issues/124