### PR TITLE
minor fix docs, add '-n' and '--' to exec cmd

### DIFF
--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -30,7 +30,7 @@ the Helm chart.
    $ helm repo add backube https://backube.github.io/helm-charts/
 
    # Deploy the chart in your cluster
-   $ helm install --create-namespace scribe-system scribe backube/scribe
+   $ helm install --create-namespace -n scribe-system scribe backube/scribe
 
 Verify Scribe is running by checking the output of ``kubectl get pods``:
 

--- a/docs/usage/rsync/database_example.rst
+++ b/docs/usage/rsync/database_example.rst
@@ -83,7 +83,7 @@ Create a database in the mysql pod running in the source namespace.
 
 .. code:: bash
 
-   $ kubectl exec --stdin --tty -n source `kubectl get pods -n source | grep mysql | awk '{print $1}'` /bin/bash
+   $ kubectl exec --stdin --tty -n source `kubectl get pods -n source | grep mysql | awk '{print $1}'` -- /bin/bash
    $ mysql -u root -p$MYSQL_ROOT_PASSWORD
    > show databases;
    +--------------------+
@@ -127,7 +127,7 @@ exists.
 
 .. code:: bash
 
-   $ kubectl exec --stdin --tty -n dest `kubectl get pods -n dest | grep mysql | awk '{print $1}'` /bin/bash
+   $ kubectl exec --stdin --tty -n dest `kubectl get pods -n dest | grep mysql | awk '{print $1}'` -- /bin/bash
    $ mysql -u root -p$MYSQL_ROOT_PASSWORD
    > show databases;
    +--------------------+


### PR DESCRIPTION
helm install --create-namespace requires `--namespace` or `-n`
kubectl exec complains if don't add `-- /bin/bash` 
