### PR TITLE
Plugin:  `$ kubectl scribe start, set, continue, remove-replication` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ and names are likely to be updated frequently. PRs and new issues are welcome!
 Available commands:
 
 ```bash
-kubectl scribe new-source
-kubectl scribe new-destination
-kubectl scribe sync-ssh-secret
+kubectl scribe start-replication
+kubectl scribe set-replication
+kubectl scribe continue-replication
+kubectl scribe remove-replication
 ```
 
 * Try the current examples:

--- a/docs/usage/rsync/plugin_opts.rst
+++ b/docs/usage/rsync/plugin_opts.rst
@@ -11,6 +11,7 @@ the command-line passed :code:`--config` value that is a path to a local file.
 
 .. code:: yaml
 
+    dest-address: <remote address to connect to for replication>
     dest-name: <dest-namespace>-destination
     dest-namespace: <current namespace>
     dest-kube-context: <kubectl config current-context>
@@ -24,6 +25,10 @@ the command-line passed :code:`--config` value that is a path to a local file.
     dest-storage-class-name: <default sc>
     dest-volume-snapshot-class-name: <default vsc>
     dest-copy-method: one of None|Clone|Snapshot
+    dest-port: 22
+    dest-provider: <external replication provider, pass as 'domain.com/provider'>
+    dest-provider-params: <key=value configuration parameters, if external provider; pass as 'key=value,key1=value1'>
+    dest-path: /
     source-name: <source-namespace>-source
     source-namespace: <current namespace>
     source-kube-context: <current-context>
@@ -37,8 +42,7 @@ the command-line passed :code:`--config` value that is a path to a local file.
     source-storage-class-name: <default sc>
     source-volume-snapshot-class-name: <default vsc>
     source-copy-method: one of None|Clone|Snapshot
-    address: <remote address to connect to for replication>
-    port: 22
+    source-port: 22
+    source-provider: <external replication provider, pass as 'domain.com/provider'>
+    source-provider-params: <key=value configuration parameters, if external provider; pass as 'key=value,key1=value1'>
     ssh-keys-secret: <scribe-rsync->dest-src-<name-of-replication-destination>
-    provider: <external replication provider, pass as 'domain.com/provider'>
-    provider-params: <key=value configuration parameters, if external provider; pass as 'key=value,key1=value1'>

--- a/examples/source-database/mysql-pvc.yaml
+++ b/examples/source-database/mysql-pvc.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: mysql-pv-claim
-  namespace: source
 spec:
   accessModes:
   - ReadWriteOnce

--- a/pkg/cmd/continue_replication.go
+++ b/pkg/cmd/continue_replication.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	scribev1alpha1 "github.com/backube/scribe/api/v1alpha1"
+)
+
+var (
+	scribeContinueReplicationLong = templates.LongDesc(`
+        Scribe is a command line tool for a scribe operator running in a Kubernetes cluster.
+		Scribe asynchronously replicates Kubernetes persistent volumes between clusters or namespaces
+		The 'continue' command will remove a manual trigger from a replication source and replication
+		will resume according to the replication source schedule. Subsequent execution of 'set-replication'
+		will result in a new destination PVC. PVCs will never be deleted by Scribe.
+`)
+	scribeContinueReplicationExample = templates.Examples(`
+        # View all flags for continue-replication. 'scribe-config' can hold flag values.
+		# Scribe config holds values for source PVC, source and destination context, and other options.
+        $ scribe continue-replication --help
+
+		# Remove the manual trigger from a SourceDestination to resume replications.
+		# This command should be run after ensuring the destination application is up-to-date.
+        $ scribe continue
+
+    `)
+)
+
+func NewCmdScribeContinueReplication(streams genericclioptions.IOStreams) *cobra.Command {
+	v := viper.New()
+	o := NewFinalizeOptions(streams)
+	cmd := &cobra.Command{
+		Use:     "continue-replication [OPTIONS]",
+		Short:   i18n.T("remove a manual trigger from a scribe replication source to resume replications."),
+		Long:    fmt.Sprint(scribeContinueReplicationLong),
+		Example: fmt.Sprint(scribeContinueReplicationExample),
+		Version: ScribeVersion,
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete())
+			kcmdutil.CheckErr(o.Continue())
+		},
+	}
+	kcmdutil.CheckErr(o.Config.Bind(cmd, v))
+	o.RepOpts.Bind(cmd, v)
+	kcmdutil.CheckErr(o.Bind(cmd, v))
+
+	return cmd
+}
+
+//nolint:lll
+// Continue updates ReplicationSource to remove a manual trigger
+// the replications then proceed according to the replication source schedule.
+func (o *FinalizeOptions) Continue() error {
+	ctx := context.Background()
+	klog.Infof("Fetching ReplicationSource %s in namespace %s", o.sourceName, o.RepOpts.Source.Namespace)
+	repSource := &scribev1alpha1.ReplicationSource{}
+	sourceNSName := types.NamespacedName{
+		Namespace: o.RepOpts.Source.Namespace,
+		Name:      o.sourceName,
+	}
+	if err := o.RepOpts.Source.Client.Get(ctx, sourceNSName, repSource); err != nil {
+		return err
+	}
+	klog.Infof("Removing manual trigger from ReplicationSource: %s namespace: %s", o.RepOpts.Source.Namespace, o.sourceName)
+	repSource.Spec.Trigger = &scribev1alpha1.ReplicationSourceTriggerSpec{
+		Schedule: repSource.Spec.Trigger.Schedule,
+	}
+	if err := o.RepOpts.Source.Client.Update(ctx, repSource); err != nil {
+		return fmt.Errorf("unable to remove manual trigger for last sync: %v", err)
+	}
+	klog.Infof("ReplicationSource schedule %v restored, manual trigger removed.", *repSource.Spec.Trigger.Schedule)
+	return nil
+}

--- a/pkg/cmd/destination.go
+++ b/pkg/cmd/destination.go
@@ -1,61 +1,29 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/klog/v2"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util/i18n"
-	"k8s.io/kubectl/pkg/util/templates"
-
-	scribev1alpha1 "github.com/backube/scribe/api/v1alpha1"
 )
 
-var (
-	scribeNewDestinationLong = templates.LongDesc(`
-	    Scribe is a command line tool for a scribe operator running in a Kubernetes cluster.
-		Scribe asynchronously replicates Kubernetes persistent volumes between clusters or namespaces
-		using rsync, rclone, or restic. Scribe uses a ReplicationDestination and a ReplicationSource
-		to replicate a volume. Data will be synced according to the configured sync schedule.
-`)
-	scribeNewDestinationExample = templates.Examples(`
-        # Create a ReplicationDestination with 'scribe-config' file holding flag values in current directory.
-        $ scribe new-destination
-
-        # Create a ReplicationDestination in the namespace 'dest'.
-        $ scribe new-destination --dest-namespace dest --dest-copy-method Snapshot --dest-access-mode ReadWriteOnce
-
-        # Create a ReplicationDestination in current namespace with Snapshot copy method and pvc mysql-claim
-        $ scribe new-destination  --dest-copy-method Snapshot --dest-pvc mysql-claim
-
-		# Create a ReplicationDestination in the namespace 'dest' in cluster 'api-test-dest-com:6443' with context 'destuser'.
-        $ scribe new-destination --dest-namespace dest \
-		    --dest-copy-method Snapshot \
-			--dest-access-mode ReadWriteOnce \
-			--dest-kube-context destuser \
-			--dest-kube-clustername api-test-dest-com:6443
-    `)
-)
+var destPVCStorageClass = "gp2-csi"
 
 type DestinationOptions struct {
 	Name                    string
-	Namespace               string
-	ScribeOptions           ScribeOptions
+	Config                  Config
+	RepOpts                 ReplicationOptions
 	SSHKeysSecretOptions    SSHKeysSecretOptions
 	Schedule                string
 	CopyMethod              string
 	Capacity                string
-	StorageClassName        string
+	StorageClass            string
 	AccessMode              string
 	Address                 string
 	VolumeSnapshotClassName string
-	PVC                     string
+	DestPVC                 string
 	SSHUser                 string
 	ServiceType             string
 	Port                    int32
@@ -63,48 +31,19 @@ type DestinationOptions struct {
 	RcloneConfig            string
 	Provider                string
 	ProviderParameters      string
-	genericclioptions.IOStreams
-}
-
-func NewDestinationOptions(streams genericclioptions.IOStreams) *DestinationOptions {
-	return &DestinationOptions{
-		IOStreams: streams,
-	}
-}
-
-func NewCmdScribeNewDestination(streams genericclioptions.IOStreams) *cobra.Command {
-	v := viper.New()
-	o := NewDestinationOptions(streams)
-	cmd := &cobra.Command{
-		Use:     "new-destination [OPTIONS]",
-		Short:   i18n.T("Create a ReplicationDestination for replicating a persistent volume."),
-		Long:    fmt.Sprint(scribeNewDestinationLong),
-		Example: fmt.Sprint(scribeNewDestinationExample),
-		Version: ScribeVersion,
-		Run: func(cmd *cobra.Command, args []string) {
-			kcmdutil.CheckErr(o.Complete(cmd))
-			kcmdutil.CheckErr(o.Validate())
-			kcmdutil.CheckErr(o.CreateReplicationDestination())
-		},
-	}
-	kcmdutil.CheckErr(o.ScribeOptions.Bind(cmd, v))
-	kcmdutil.CheckErr(o.SSHKeysSecretOptions.Bind(cmd, v))
-	kcmdutil.CheckErr(o.Bind(cmd, v))
-
-	return cmd
 }
 
 //nolint:lll
-func (o *DestinationOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) error {
+func (o *DestinationOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	flags := cmd.Flags()
 	flags.StringVar(&o.CopyMethod, "dest-copy-method", o.CopyMethod, "the method of creating a point-in-time image of the destination volume; one of 'None|Clone|Snapshot'")
-	flags.StringVar(&o.Address, "address", o.Address, "the remote address to connect to for replication.")
+	flags.StringVar(&o.Address, "dest-address", o.Address, "the remote address to connect to for replication.")
 	// TODO: Defaulted with CLI, should it be??
 	flags.StringVar(&o.Capacity, "dest-capacity", "2Gi", "Size of the destination volume to create. Must be provided if --dest-pvc is not provided.")
-	flags.StringVar(&o.StorageClassName, "dest-storage-class-name", o.StorageClassName, "name of the StorageClass of the destination volume. If not set, the default StorageClass will be used.")
+	flags.StringVar(&o.StorageClass, "dest-storage-class-name", o.StorageClass, "name of the StorageClass of the destination volume. If not set, the default StorageClass will be used.")
 	flags.StringVar(&o.AccessMode, "dest-access-mode", o.AccessMode, "the access modes for the destination volume. Must be provided if --dest-pvc is not provided; One of 'ReadWriteOnce|ReadOnlyMany|ReadWriteMany")
 	flags.StringVar(&o.VolumeSnapshotClassName, "dest-volume-snapshot-class", o.VolumeSnapshotClassName, "name of the VolumeSnapshotClass to be used for the destination volume, only if the copyMethod is 'Snapshot'. If not set, the default VSC will be used.")
-	flags.StringVar(&o.PVC, "dest-pvc", o.PVC, "name of an existing PVC to use as the transfer destination volume instead of automatically provisioning one.")
+	flags.StringVar(&o.DestPVC, "dest-pvc", o.DestPVC, "name of an existing empty PVC in the destination namespace to use as the transfer destination volume. If empty, one will be provisioned.")
 	flags.StringVar(&o.Schedule, "dest-cron-spec", o.Schedule, "cronspec to be used to schedule replication to occur at regular, time-based intervals. If not set replication will be continuous.")
 	// Defaults to "root" after creation
 	flags.StringVar(&o.SSHUser, "dest-ssh-user", o.SSHUser, "username for outgoing SSH connections (default 'root')")
@@ -112,12 +51,12 @@ func (o *DestinationOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) error
 	flags.StringVar(&o.ServiceType, "dest-service-type", o.ServiceType, "one of ClusterIP|LoadBalancer. Service type to be created for incoming SSH connections. (default 'ClusterIP')")
 	// TODO: Defaulted in CLI, should it be??
 	flags.StringVar(&o.Name, "dest-name", o.Name, "name of the ReplicationDestination resource. (default '<current-namespace>-scribe-destination')")
-	flags.Int32Var(&o.Port, "port", o.Port, "SSH port to connect to for replication. (default 22)")
-	flags.StringVar(&o.Provider, "provider", o.Provider, "name of an external replication provider, if applicable; pass as 'domain.com/provider'")
+	flags.Int32Var(&o.Port, "dest-port", o.Port, "SSH port to connect to for replication. (default 22)")
+	flags.StringVar(&o.Provider, "dest-provider", o.Provider, "name of an external replication provider, if applicable; pass as 'domain.com/provider'")
 	// TODO: I don't know how many params providers have? If a lot, can pass a file instead
-	flags.StringVar(&o.ProviderParameters, "provider-parameters", o.ProviderParameters, "provider-specific key=value configuration parameters, for an external provider; pass 'key=value,key1=value1'")
+	flags.StringVar(&o.ProviderParameters, "dest-provider-parameters", o.ProviderParameters, "provider-specific key=value configuration parameters, for an external provider; pass 'key=value,key1=value1'")
 	// defaults to "/" after creation
-	flags.StringVar(&o.Path, "path", o.Path, "the remote path to rsync to (default '/')")
+	flags.StringVar(&o.Path, "dest-path", o.Path, "the remote path to rsync to (default '/')")
 	if err := cmd.MarkFlagRequired("dest-copy-method"); err != nil {
 		return err
 	}
@@ -127,130 +66,5 @@ func (o *DestinationOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) error
 			kcmdutil.CheckErr(flags.Set(f.Name, fmt.Sprintf("%v", val)))
 		}
 	})
-	return nil
-}
-
-func (o *DestinationOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
-	// config file in current directory
-	// TODO: where to look for config file
-	v.SetConfigName(scribeConfig)
-	v.AddConfigPath(".")
-	v.SetConfigType("yaml")
-	if err := v.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			return err
-		}
-	}
-	return o.bindFlags(cmd, v)
-}
-
-func (o *DestinationOptions) Complete(cmd *cobra.Command) error {
-	err := o.ScribeOptions.Complete()
-	if err != nil {
-		return err
-	}
-	o.Namespace = o.ScribeOptions.DestNamespace
-	if len(o.Name) == 0 {
-		o.Name = o.Namespace + "-destination"
-	}
-	klog.V(2).Infof("replication destination %s will be created in %s namespace", o.Name, o.Namespace)
-	return nil
-}
-
-// Validate validates ReplicationDestination options.
-func (o *DestinationOptions) Validate() error {
-	if len(o.CopyMethod) == 0 {
-		return fmt.Errorf("must provide --dest-copy-method; one of 'None|Clone|Snapshot'")
-	}
-	if len(o.Capacity) == 0 && len(o.PVC) == 0 {
-		return fmt.Errorf("must either provide --dest-capacity & --dest-access-mode OR --dest-pvc")
-	}
-	if len(o.AccessMode) == 0 && len(o.PVC) == 0 {
-		return fmt.Errorf("must either provide --dest-capacity & --dest-access-mode OR --dest-pvc")
-	}
-	return nil
-}
-
-func (o *DestinationOptions) commonOptions() (*CommonOptions, error) {
-	repOpts := &ReplicationOptions{
-		CopyMethod:              o.CopyMethod,
-		Capacity:                o.Capacity,
-		StorageClassName:        o.StorageClassName,
-		AccessMode:              o.AccessMode,
-		Address:                 o.Address,
-		VolumeSnapshotClassName: o.VolumeSnapshotClassName,
-		PVC:                     o.PVC,
-		SSHUser:                 o.SSHUser,
-		ServiceType:             o.ServiceType,
-		Port:                    o.Port,
-		Path:                    o.Path,
-		RcloneConfig:            o.RcloneConfig,
-		Provider:                o.Provider,
-		ProviderParameters:      o.ProviderParameters,
-	}
-	return repOpts.GetCommonOptions()
-}
-
-// CreateReplicationDestination creates a ReplicationDestination resource
-func (o *DestinationOptions) CreateReplicationDestination() error {
-	c, err := o.commonOptions()
-	if err != nil {
-		return err
-	}
-	var sshKeysSecret *string
-	switch {
-	case len(o.SSHKeysSecretOptions.SSHKeysSecret) > 0:
-		sshKeysSecret = &o.SSHKeysSecretOptions.SSHKeysSecret
-	default:
-		sshKeysSecret = nil
-	}
-	triggerSpec := &scribev1alpha1.ReplicationDestinationTriggerSpec{
-		Schedule: &o.Schedule,
-	}
-	if len(o.Schedule) == 0 {
-		triggerSpec = nil
-	}
-	rsyncSpec := &scribev1alpha1.ReplicationDestinationRsyncSpec{
-		ReplicationDestinationVolumeOptions: scribev1alpha1.ReplicationDestinationVolumeOptions{
-			CopyMethod:              c.CopyMethod,
-			Capacity:                c.Capacity,
-			StorageClassName:        c.StorageClassName,
-			AccessModes:             c.AccessModes,
-			VolumeSnapshotClassName: c.VolumeSnapClassName,
-			DestinationPVC:          c.PVC,
-		},
-		SSHKeys:     sshKeysSecret,
-		SSHUser:     c.SSHUser,
-		Address:     c.Address,
-		ServiceType: &c.ServiceType,
-		Port:        c.Port,
-		Path:        c.Path,
-	}
-	var externalSpec *scribev1alpha1.ReplicationDestinationExternalSpec
-	if len(o.Provider) > 0 && c.Parameters != nil {
-		externalSpec = &scribev1alpha1.ReplicationDestinationExternalSpec{
-			Provider:   o.Provider,
-			Parameters: c.Parameters,
-		}
-	}
-	rd := &scribev1alpha1.ReplicationDestination{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "scribe.backube/v1alpha1",
-			Kind:       "ReplicationDestination",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      o.Name,
-			Namespace: o.Namespace,
-		},
-		Spec: scribev1alpha1.ReplicationDestinationSpec{
-			Trigger:  triggerSpec,
-			Rsync:    rsyncSpec,
-			External: externalSpec,
-		},
-	}
-	if err := o.ScribeOptions.DestinationClient.Create(context.TODO(), rd); err != nil {
-		return err
-	}
-	klog.V(0).Infof("ReplicationDestination %s created in namespace %s", o.Name, o.Namespace)
 	return nil
 }

--- a/pkg/cmd/destination.go
+++ b/pkg/cmd/destination.go
@@ -9,7 +9,9 @@ import (
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
-var destPVCStorageClass = "gp2-csi"
+// This will be passed to scribe as 'nil' that will
+// result in defaulting to the cluster's default storage class
+var destPVCDefaultStorageClass = ""
 
 type DestinationOptions struct {
 	Name                    string
@@ -40,7 +42,7 @@ func (o *DestinationOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	flags.StringVar(&o.Address, "dest-address", o.Address, "the remote address to connect to for replication.")
 	// TODO: Defaulted with CLI, should it be??
 	flags.StringVar(&o.Capacity, "dest-capacity", "2Gi", "Size of the destination volume to create. Must be provided if --dest-pvc is not provided.")
-	flags.StringVar(&o.StorageClass, "dest-storage-class-name", o.StorageClass, "name of the StorageClass of the destination volume. If not set, the default StorageClass will be used.")
+	flags.StringVar(&o.StorageClass, "dest-storage-class", o.StorageClass, "name of the StorageClass of the destination volume. If not set, the default StorageClass will be used.")
 	flags.StringVar(&o.AccessMode, "dest-access-mode", o.AccessMode, "the access modes for the destination volume. Must be provided if --dest-pvc is not provided; One of 'ReadWriteOnce|ReadOnlyMany|ReadWriteMany")
 	flags.StringVar(&o.VolumeSnapshotClassName, "dest-volume-snapshot-class", o.VolumeSnapshotClassName, "name of the VolumeSnapshotClass to be used for the destination volume, only if the copyMethod is 'Snapshot'. If not set, the default VSC will be used.")
 	flags.StringVar(&o.DestPVC, "dest-pvc", o.DestPVC, "name of an existing empty PVC in the destination namespace to use as the transfer destination volume. If empty, one will be provisioned.")

--- a/pkg/cmd/remove_replication.go
+++ b/pkg/cmd/remove_replication.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	scribev1alpha1 "github.com/backube/scribe/api/v1alpha1"
+)
+
+var (
+	scribeRemoveReplicationLong = templates.LongDesc(`
+        Scribe is a command line tool for a scribe operator running in a Kubernetes cluster.
+		Scribe asynchronously replicates Kubernetes persistent volumes between clusters or namespaces
+		using rsync, rclone, or restic. The remove-replication command will remove the scribe
+		replication destination, replication source, and their resources. This command should be
+		executed after the destination application is verified to be up-to-date and the destination PVC
+		is bound to the destination application. The destination PVC and the source PVC are not modified.
+		PVCs will never be deleted by Scribe.
+`)
+	scribeRemoveReplicationExample = templates.Examples(`
+        # View all flags for remove-replication. 'scribe-config' can hold flag values.
+		# Scribe config holds values for source PVC, source and destination context, and other options.
+        $ scribe remove-replication --help
+
+		# Remove a scribe replication and its resources. The destination PVC is not deleted or modified.
+        $ scribe remove-replication
+
+    `)
+)
+
+func NewCmdScribeRemoveReplication(streams genericclioptions.IOStreams) *cobra.Command {
+	v := viper.New()
+	o := NewFinalizeOptions(streams)
+	cmd := &cobra.Command{
+		Use:     "remove-replication [OPTIONS]",
+		Short:   i18n.T("Remove a scribe replication and its resources."),
+		Long:    fmt.Sprint(scribeRemoveReplicationLong),
+		Example: fmt.Sprint(scribeRemoveReplicationExample),
+		Version: ScribeVersion,
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete())
+			kcmdutil.CheckErr(o.RemoveReplication())
+		},
+	}
+	kcmdutil.CheckErr(o.Config.Bind(cmd, v))
+	o.RepOpts.Bind(cmd, v)
+	kcmdutil.CheckErr(o.Bind(cmd, v))
+
+	return cmd
+}
+
+//nolint:lll
+// RemoveReplication does the following:
+// 0) Checks ReplicationSource,Destination are connected (same rsync address)
+// 1) Removes ReplicationSource
+// 2) Removes synced sshSecret from source namespace
+// 3) Removed ReplicationDestination
+func (o *FinalizeOptions) RemoveReplication() error {
+	ctx := context.Background()
+	repSource := &scribev1alpha1.ReplicationSource{}
+	sourceNSName := types.NamespacedName{
+		Namespace: o.RepOpts.Source.Namespace,
+		Name:      o.sourceName,
+	}
+	if err := o.RepOpts.Source.Client.Get(ctx, sourceNSName, repSource); err != nil {
+		return err
+	}
+	repDest := &scribev1alpha1.ReplicationDestination{}
+	destNSName := types.NamespacedName{
+		Namespace: o.RepOpts.Dest.Namespace,
+		Name:      o.destName,
+	}
+	if err := o.RepOpts.Dest.Client.Get(ctx, destNSName, repDest); err != nil {
+		return err
+	}
+	if *repSource.Spec.Rsync.Address != *repDest.Status.Rsync.Address {
+		klog.Info("Refusing to remove replication, source and destination do not match")
+		return fmt.Errorf("Source RsyncAddress: %v does not match Destination RsyncAddress: %v", *repSource.Spec.Rsync.Address, *repDest.Status.Rsync.Address)
+	}
+	sshSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: o.RepOpts.Source.Namespace,
+			Name:      *repSource.Spec.Rsync.SSHKeys,
+		},
+	}
+	if err := o.RepOpts.Source.Client.Delete(ctx, sshSecret); err != nil {
+		return fmt.Errorf("error deleting ssh-keys: %s namespace: %s: %v", sshSecret.Name, o.RepOpts.Source.Namespace, err)
+	}
+	klog.Infof("Deleted source SSH secret %s in namespace %s", sshSecret.Name, o.RepOpts.Source.Namespace)
+
+	if err := o.RepOpts.Source.Client.Delete(ctx, repSource); err != nil {
+		return fmt.Errorf("error deleting replication source: %s namespace: %s: %v", o.sourceName, o.RepOpts.Source.Namespace, err)
+	}
+	klog.Infof("Deleted replication source %s in namespace %s", o.sourceName, o.RepOpts.Source.Namespace)
+
+	if err := o.RepOpts.Dest.Client.Delete(ctx, repDest); err != nil {
+		return fmt.Errorf("error deleting replication destination: %s namespace: %s: %v", o.destName, o.RepOpts.Dest.Namespace, err)
+	}
+	klog.Infof("Deleted replication destination %s in namespace %s", o.destName, o.RepOpts.Dest.Namespace)
+
+	klog.Infof("Scribe remove-replication complete.")
+	return nil
+}

--- a/pkg/cmd/scribe.go
+++ b/pkg/cmd/scribe.go
@@ -92,7 +92,7 @@ func (o *ScribeSourceOptions) Bind(cmd *cobra.Command, v *viper.Viper) {
 	flags := cmd.Flags()
 	flags.StringVar(&o.KubeContext, "source-kube-context", o.KubeContext, "the name of the kubeconfig context to use for the destination cluster. Defaults to current-context.")
 	flags.StringVar(&o.KubeClusterName, "source-kube-clustername", o.KubeClusterName, "the name of the kubeconfig cluster to use for the destination cluster. Defaults to current cluster.")
-	flags.StringVar(&o.Namespace, "source-namespace", o.Namespace, "the transfer source namespace and/or location of a ReplicationSource. This namespace must exist. default is current namespace.")
+	flags.StringVar(&o.Namespace, "source-namespace", o.Namespace, "the transfer source namespace and/or location of a ReplicationSource. This namespace must exist. Defaults to current namespace.")
 	flags.VisitAll(func(f *pflag.Flag) {
 		// Apply the viper config value to the flag when the flag is not set and viper has a value
 		if v.IsSet(f.Name) {
@@ -107,7 +107,7 @@ func (o *ScribeDestinationOptions) Bind(cmd *cobra.Command, v *viper.Viper) {
 	flags := cmd.Flags()
 	flags.StringVar(&o.KubeContext, "dest-kube-context", o.KubeContext, "the name of the kubeconfig context to use for the destination cluster. Defaults to current-context.")
 	flags.StringVar(&o.KubeClusterName, "dest-kube-clustername", o.KubeClusterName, "the name of the kubeconfig cluster to use for the destination cluster. Defaults to current-cluster.")
-	flags.StringVar(&o.Namespace, "dest-namespace", o.Namespace, "the transfer destination namespace and/or location of a ReplicationDestination. This namespace must exist. If not set, use the current namespace.")
+	flags.StringVar(&o.Namespace, "dest-namespace", o.Namespace, "the transfer destination namespace and/or location of a ReplicationDestination. This namespace must exist. Defaults to current namespace.")
 	flags.VisitAll(func(f *pflag.Flag) {
 		// Apply the viper config value to the flag when the flag is not set and viper has a value
 		if v.IsSet(f.Name) {
@@ -130,7 +130,7 @@ func (o *Config) bindFlags(cmd *cobra.Command, v *viper.Viper) {
 	})
 }
 
-func (o *Config) complete(cmd *cobra.Command, v *viper.Viper) error {
+func (o *Config) complete(v *viper.Viper) error {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return err
@@ -170,7 +170,7 @@ func (o *Config) complete(cmd *cobra.Command, v *viper.Viper) error {
 
 func (o *Config) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	o.bindFlags(cmd, v)
-	if err := o.complete(cmd, v); err != nil {
+	if err := o.complete(v); err != nil {
 		return err
 	}
 	return nil
@@ -197,7 +197,9 @@ func NewCmdScribe(in io.Reader, out, errout io.Writer) *cobra.Command {
 		},
 	}
 	scribecmd.AddCommand(NewCmdScribeStartReplication(streams))
-	//scribecmd.AddCommand(NewCmdScribeFinalizeReplication(streams))
+	scribecmd.AddCommand(NewCmdScribeSetReplication(streams))
+	scribecmd.AddCommand(NewCmdScribeContinueReplication(streams))
+	scribecmd.AddCommand(NewCmdScribeRemoveReplication(streams))
 
 	return scribecmd
 }
@@ -214,6 +216,7 @@ func (o *ReplicationOptions) Complete() error {
 	return nil
 }
 
+//nolint:dupl
 func (o *ScribeSourceOptions) Complete() error {
 	sourceKubeConfigFlags := genericclioptions.NewConfigFlags(true)
 	if len(o.KubeContext) > 0 {
@@ -245,6 +248,7 @@ func (o *ScribeSourceOptions) Complete() error {
 	return nil
 }
 
+//nolint:dupl
 func (o *ScribeDestinationOptions) Complete() error {
 	destKubeConfigFlags := genericclioptions.NewConfigFlags(true)
 	if len(o.KubeContext) > 0 {

--- a/pkg/cmd/set_replication.go
+++ b/pkg/cmd/set_replication.go
@@ -1,0 +1,228 @@
+//nolint:lll
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
+	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	scribev1alpha1 "github.com/backube/scribe/api/v1alpha1"
+)
+
+var (
+	scribeSetReplicationLong = templates.LongDesc(`
+        Scribe is a command line tool for a scribe operator running in a Kubernetes cluster.
+		Scribe asynchronously replicates Kubernetes persistent volumes between clusters or namespaces
+		using rsync, rclone, or restic. The set-replication command creates a PersistentVolumeClaim in
+		the destination namespace with the latest image from the ReplicationDestination used as the
+		data source for the PVC, in the case of destination CopyMethod=Snapshot.
+		In the case of destination CopyMethod=None, the destination PVC is
+		already created since the data is synced directly from source PVC to destination PVC.
+		One more full data sync will be completed, then replications are paused. This leaves your
+		destination application ready to bind to the destination PVC.
+`)
+	scribeSetReplicationExample = templates.Examples(`
+        # View all flags for set-replication. 'scribe-config' can hold flag values.
+		# Scribe config holds values for source PVC, source and destination context, and other options.
+        $ scribe set-replication --help
+
+        # Start a Replication with 'scribe-config' file holding flag values in current directory.
+		# Scribe config holds values for source PVC, source and destination context, and other options.
+		# You may also pass any flags as command line options. Command line options will override those
+		# in the config file.
+        $ scribe set-replication
+
+    `)
+)
+
+type FinalizeOptions struct {
+	Config           Config
+	RepOpts          ReplicationOptions
+	sourceName       string
+	destName         string
+	destPVC          string
+	destStorageClass string
+	destCapacity     string
+	timeout          time.Duration
+	genericclioptions.IOStreams
+}
+
+func NewFinalizeOptions(streams genericclioptions.IOStreams) *FinalizeOptions {
+	return &FinalizeOptions{
+		IOStreams: streams,
+	}
+}
+
+func NewCmdScribeSetReplication(streams genericclioptions.IOStreams) *cobra.Command {
+	v := viper.New()
+	o := NewFinalizeOptions(streams)
+	cmd := &cobra.Command{
+		Use:     "set-replication [OPTIONS]",
+		Short:   i18n.T("Set and pause a scribe replication and ensure a destination PVC with synced data."),
+		Long:    fmt.Sprint(scribeSetReplicationLong),
+		Example: fmt.Sprint(scribeSetReplicationExample),
+		Version: ScribeVersion,
+		Run: func(cmd *cobra.Command, args []string) {
+			kcmdutil.CheckErr(o.Complete())
+			kcmdutil.CheckErr(o.SetReplication())
+		},
+	}
+	kcmdutil.CheckErr(o.Config.Bind(cmd, v))
+	o.RepOpts.Bind(cmd, v)
+	kcmdutil.CheckErr(o.Bind(cmd, v))
+
+	return cmd
+}
+
+func (o *FinalizeOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) error {
+	flags := cmd.Flags()
+	flags.StringVar(&o.sourceName, "source-replication-name", o.sourceName, "name of ReplicationSource (default '<source-ns>-source')")
+	flags.StringVar(&o.destName, "dest-replication-name", o.destName, "name of ReplicationDestination (default '<dest-ns>-destination') ")
+	flags.StringVar(&o.destPVC, "dest-pvc", o.destPVC, "name of not-yet-existing destination PVC. Default is sourcePVC name, or if PVC with sourcePVC name exists in destination namespace, then 'sourcePVC-<date-tag>'")
+	flags.StringVar(&o.destCapacity, "dest-capacity", o.destCapacity, "size of the destination volume to create. Default is source volume capacity.")
+	flags.StringVar(&o.destStorageClass, "dest-storage-class", o.destStorageClass, "name of the StorageClass of the destination volume. If not set, the default StorageClass will be used.")
+	flags.DurationVar(&o.timeout, "timeout", time.Minute*5, "length of time to wait for final sync to complete. Default is 5m. Pass values as time unit (e.g. 1,, 2m, 3h)")
+	flags.VisitAll(func(f *pflag.Flag) {
+		if !f.Changed && v.IsSet(f.Name) {
+			val := v.Get(f.Name)
+			kcmdutil.CheckErr(flags.Set(f.Name, fmt.Sprintf("%v", val)))
+		}
+	})
+	return nil
+}
+
+func (o *FinalizeOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
+	v.SetConfigName(scribeConfig)
+	v.AddConfigPath(".")
+	v.SetConfigType("yaml")
+	if err := v.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return err
+		}
+	}
+	return o.bindFlags(cmd, v)
+}
+
+func (o *FinalizeOptions) Complete() error {
+	if err := o.RepOpts.Complete(); err != nil {
+		return err
+	}
+	if len(o.destName) == 0 {
+		o.destName = fmt.Sprintf("%s-destination", o.RepOpts.Dest.Namespace)
+	}
+	if len(o.sourceName) == 0 {
+		o.sourceName = fmt.Sprintf("%s-source", o.RepOpts.Source.Namespace)
+	}
+	return nil
+}
+
+//nolint:funlen
+// SetReplication does the following:
+// 1) Performs manually triggered sync as the last sync
+// 2) Create DestinationPVC if CopyMethod=Snapshot
+// With the manual trigger in place, no further replications will execute.
+func (o *FinalizeOptions) SetReplication() error {
+	lastManualSync := time.Now().Format("2006-01-02t15-04-05")
+	ctx := context.Background()
+	klog.Infof("Fetching ReplicationSource %s in namespace %s", o.sourceName, o.RepOpts.Source.Namespace)
+	repSource := &scribev1alpha1.ReplicationSource{}
+	sourceNSName := types.NamespacedName{
+		Namespace: o.RepOpts.Source.Namespace,
+		Name:      o.sourceName,
+	}
+	if err := o.RepOpts.Source.Client.Get(ctx, sourceNSName, repSource); err != nil {
+		return err
+	}
+	klog.Infof("Triggering final data sync")
+	repSource.Spec.Trigger = &scribev1alpha1.ReplicationSourceTriggerSpec{
+		Schedule: repSource.Spec.Trigger.Schedule,
+		Manual:   lastManualSync,
+	}
+	if err := o.RepOpts.Source.Client.Update(ctx, repSource); err != nil {
+		return fmt.Errorf("unable to set manual trigger for last sync")
+	}
+	if err := wait.PollImmediate(5*time.Second, o.timeout, func() (bool, error) {
+		if err := o.RepOpts.Source.Client.Get(ctx, sourceNSName, repSource); err != nil {
+			return false, err
+		}
+		if repSource.Status.LastManualSync != lastManualSync {
+			return false, nil
+		}
+		klog.Infof("Last data sync complete")
+		return true, nil
+	}); err != nil {
+		return err
+	}
+	srcPVC := &corev1.PersistentVolumeClaim{}
+	sourcePVCName := types.NamespacedName{
+		Namespace: o.RepOpts.Source.Namespace,
+		Name:      repSource.Spec.SourcePVC,
+	}
+	if err := o.RepOpts.Source.Client.Get(ctx, sourcePVCName, srcPVC); err != nil {
+		return err
+	}
+	repDest := &scribev1alpha1.ReplicationDestination{}
+	destNSName := types.NamespacedName{
+		Namespace: o.RepOpts.Dest.Namespace,
+		Name:      o.destName,
+	}
+	if err := o.RepOpts.Dest.Client.Get(ctx, destNSName, repDest); err != nil {
+		return err
+	}
+	var (
+		latestImage *corev1.TypedLocalObjectReference
+		destPVCName string
+		err         error
+	)
+	if repDest.Spec.Rsync.CopyMethod == scribev1alpha1.CopyMethodNone {
+		destPVCName = *repDest.Spec.Rsync.DestinationPVC
+		if len(destPVCName) == 0 {
+			return fmt.Errorf("destination PVC not listed in ReplicationDestination: %s", repDest.Name)
+		}
+	} else {
+		latestImage = repDest.Status.LatestImage
+		if latestImage == nil {
+			return fmt.Errorf("ReplicationDestination does not have a latest snapshot image, exiting")
+		}
+		// if destPVC is empty, destination PVC name will be generated from source PVC
+		destOpts := DestinationOptions{
+			DestPVC: o.destPVC,
+		}
+		repOpts := &SetupReplicationOptions{
+			RepOpts:      o.RepOpts,
+			DestOpts:     destOpts,
+			SourcePVC:    srcPVC.Name,
+			StorageClass: o.destStorageClass,
+		}
+		if len(o.destCapacity) == 0 {
+			repOpts.RepOpts.Dest.Capacity = srcPVC.Spec.Resources.Requests[corev1.ResourceStorage]
+		} else {
+			if err = repOpts.getCapacity(o.destCapacity, scribeDest); err != nil {
+				return err
+			}
+		}
+		destPVCName, err = repOpts.CreateDestinationPVCFromSource(ctx, latestImage)
+		if err != nil {
+			return err
+		}
+	}
+
+	klog.Infof("Scribe set-replication complete.")
+	klog.Infof("Scribe data sync complete. Destination CopyMethod %v.", repSource.Spec.Rsync.CopyMethod)
+	klog.Infof("Replications paused until manual trigger is removed from source %s", repSource.Name)
+	klog.Infof("It is now possible to edit the destination application to connect to the destination PVC: %s", destPVCName)
+	klog.Info("Run 'continue-replication' to unpause and continue replications")
+	return nil
+}

--- a/pkg/cmd/source.go
+++ b/pkg/cmd/source.go
@@ -3,11 +3,17 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	corev1 "k8s.io/api/core/v1"
+	kerrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -18,91 +24,90 @@ import (
 )
 
 var (
-	scribeNewSourceLong = templates.LongDesc(`
+	scribeStartReplicationLong = templates.LongDesc(`
         Scribe is a command line tool for a scribe operator running in a Kubernetes cluster.
 		Scribe asynchronously replicates Kubernetes persistent volumes between clusters or namespaces
 		using rsync, rclone, or restic. Scribe uses a ReplicationDestination and a ReplicationSource to
 		replicate a volume. Data will be synced according to the configured sync schedule.
+		The start-replication command will create a ReplicationDestination, ReplicationSource,
+		synced SSH keys secret from destination to source, and destination PVC that is a copy of
+		the source PVC, with specified modifications, such as storage-class. 
 `)
-	scribeNewSourceExample = templates.Examples(`
-        # Create a ReplicationSource with 'scribe-config' file holding flag values in current directory.
-        scribe new-source
+	scribeStartReplicationExample = templates.Examples(`
+        # View all flags for start-replication. 'scribe-config' can hold flag values.
+		# Scribe config holds values for source PVC, source and destination context, and other options.
+        $ scribe start-replication --help
 
-        # Create a ReplicationSource for mysql-pvc using Snapshot copy method in the namespace 'source'.
-        $ scribe new-source --source-namespace source --source-copy-method Snapshot --source-pvc mysql-pvc
+        # Start a Replication with 'scribe-config' file holding flag values in current directory.
+		# Scribe config holds values for source PVC, source and destination context, and other options.
+		# You may also pass any flags as command line options. Command line options will override those
+		# in the config file.
+        $ scribe start-replication
 
-        # Create a ReplicationSource for mysql-pvc using Snapshot copy method in the namespace 'source'
-		# in clustername 'api-source-test-com:6443' with context 'user-scribe'.
-        $ scribe new-source --source-namespace source \
-		    --source-copy-method Snapshot --source-pvc mysql-pvc \
-			--source-kube-context user-scribe --source-clustername api-source-test-com:6443
-
-        # Create a ReplicationSource for mysql-pvc using Clone copy method in the current namespace.
-        $ scribe new-source --source-copy-method Clone --source-pvc mysql-pvc
     `)
 )
 
-type SourceOptions struct {
+type SetupReplicationOptions struct {
 	Name                    string
-	Namespace               string
-	ScribeOptions           ScribeOptions
+	Config                  Config
+	RepOpts                 ReplicationOptions
 	SSHKeysSecretOptions    SSHKeysSecretOptions
+	DestOpts                DestinationOptions
+	SourcePVC               string
 	Schedule                string
 	CopyMethod              string
 	Capacity                string
-	StorageClassName        string
+	StorageClass            string
 	AccessMode              string
-	Address                 string
 	VolumeSnapshotClassName string
-	PVC                     string
 	SSHUser                 string
 	ServiceType             string
 	Port                    int32
-	Path                    string
 	RcloneConfig            string
 	Provider                string
 	ProviderParameters      string
 	genericclioptions.IOStreams
 }
 
-func NewSourceOptions(streams genericclioptions.IOStreams) *SourceOptions {
-	return &SourceOptions{
+func NewSetupReplicationOptions(streams genericclioptions.IOStreams) *SetupReplicationOptions {
+	return &SetupReplicationOptions{
 		IOStreams: streams,
 	}
 }
 
-func NewCmdScribeNewSource(streams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdScribeStartReplication(streams genericclioptions.IOStreams) *cobra.Command {
 	v := viper.New()
-	o := NewSourceOptions(streams)
+	o := NewSetupReplicationOptions(streams)
 	cmd := &cobra.Command{
-		Use:     "new-source [OPTIONS]",
-		Short:   i18n.T("Create a ReplicationSource for replicating a persistent volume."),
-		Long:    fmt.Sprint(scribeNewSourceLong),
-		Example: fmt.Sprint(scribeNewSourceExample),
+		Use:     "start-replication [OPTIONS]",
+		Short:   i18n.T("Start a scribe replication for  a persistent volume."),
+		Long:    fmt.Sprint(scribeStartReplicationLong),
+		Example: fmt.Sprint(scribeStartReplicationExample),
 		Version: ScribeVersion,
 		Run: func(cmd *cobra.Command, args []string) {
-			kcmdutil.CheckErr(o.Complete(cmd))
+			kcmdutil.CheckErr(o.Complete())
 			kcmdutil.CheckErr(o.Validate())
-			kcmdutil.CheckErr(o.CreateReplicationSource())
+			kcmdutil.CheckErr(o.StartReplication())
 		},
 	}
-	kcmdutil.CheckErr(o.ScribeOptions.Bind(cmd, v))
-	kcmdutil.CheckErr(o.SSHKeysSecretOptions.Bind(cmd, v))
+	kcmdutil.CheckErr(o.Config.Bind(cmd, v))
+	o.DestOpts.Bind(cmd, v)
+	o.RepOpts.Bind(cmd, v)
+	o.SSHKeysSecretOptions.Bind(cmd, v)
 	kcmdutil.CheckErr(o.Bind(cmd, v))
 
 	return cmd
 }
 
 //nolint:lll
-func (o *SourceOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) error {
+func (o *SetupReplicationOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 	flags := cmd.Flags()
 	flags.StringVar(&o.CopyMethod, "source-copy-method", o.CopyMethod, "the method of creating a point-in-time image of the source volume; one of 'None|Clone|Snapshot'")
-	flags.StringVar(&o.Address, "address", o.Address, "the remote address to connect to for replication.")
 	flags.StringVar(&o.Capacity, "source-capacity", o.Capacity, "provided to override the capacity of the point-in-Time image.")
-	flags.StringVar(&o.StorageClassName, "source-storage-class-name", o.StorageClassName, "provided to override the StorageClass of the point-in-Time image.")
+	flags.StringVar(&o.StorageClass, "source-storage-class-name", o.StorageClass, "provided to override the StorageClass of the point-in-Time image.")
 	flags.StringVar(&o.AccessMode, "source-access-mode", o.AccessMode, "provided to override the accessModes of the point-in-Time image. One of 'ReadWriteOnce|ReadOnlyMany|ReadWriteMany")
 	flags.StringVar(&o.VolumeSnapshotClassName, "source-volume-snapshot-class", o.VolumeSnapshotClassName, "name of VolumeSnapshotClass for the source volume, only if copyMethod is 'Snapshot'. If empty, default VSC will be used.")
-	flags.StringVar(&o.PVC, "source-pvc", o.PVC, "name of an existing PersistentVolumeClaim (PVC) to replicate.")
+	flags.StringVar(&o.SourcePVC, "source-pvc", o.SourcePVC, "name of an existing PersistentVolumeClaim (PVC) to replicate.")
 	// TODO: Default to every 3min for source?
 	flags.StringVar(&o.Schedule, "source-cron-spec", "*/5 * * * *", "cronspec to be used to schedule capturing the state of the source volume.")
 	// Defaults to "root" after creation
@@ -110,14 +115,13 @@ func (o *SourceOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 	// Defaults to ClusterIP after creation
 	flags.StringVar(&o.ServiceType, "source-service-type", o.ServiceType, "one of ClusterIP|LoadBalancer. Service type that will be created for incoming SSH connections. (default 'ClusterIP')")
 	// TODO: Defaulted in CLI, should it be??
-	flags.StringVar(&o.Name, "source-name", o.Name, "name of the ReplicationSource resource (default '<source-ns>-scribe-source')")
+	flags.StringVar(&o.Name, "source-name", o.Name, "name of the ReplicationSource resource (default '<source-ns>-source')")
 	// defaults to 22 after creation
-	flags.Int32Var(&o.Port, "port", o.Port, "SSH port to connect to for replication. (default 22)")
-	flags.StringVar(&o.Provider, "provider", o.Provider, "name of an external replication provider, if applicable; pass as 'domain.com/provider'")
+	flags.Int32Var(&o.Port, "source-port", o.Port, "SSH port to connect to for replication. (default 22)")
+	flags.StringVar(&o.Provider, "source-provider", o.Provider, "name of an external replication provider, if applicable; pass as 'domain.com/provider'")
 	// TODO: I don't know how many params providers have? If a lot, can pass a file instead
-	flags.StringVar(&o.ProviderParameters, "provider-parameters", o.ProviderParameters, "provider-specific key=value configuration parameters, for an external provider; pass 'key=value,key1=value1'")
-	// defaults to "/" after creation
-	flags.StringVar(&o.Path, "path", o.Path, "the remote path to rsync to (default '/')")
+	flags.StringVar(&o.ProviderParameters, "source-provider-parameters", o.ProviderParameters, "provider-specific key=value configuration parameters, for an external provider; pass 'key=value,key1=value1'")
+	// TODO: Defaulted with CLI, should it be??
 	if err := cmd.MarkFlagRequired("source-copy-method"); err != nil {
 		return err
 	}
@@ -133,9 +137,7 @@ func (o *SourceOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 	return nil
 }
 
-func (o *SourceOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
-	// config file in current directory
-	// TODO: where to look for config file
+func (o *SetupReplicationOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	v.SetConfigName(scribeConfig)
 	v.AddConfigPath(".")
 	v.SetConfigType("yaml")
@@ -147,65 +149,158 @@ func (o *SourceOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
 	return o.bindFlags(cmd, v)
 }
 
-func (o *SourceOptions) Complete(cmd *cobra.Command) error {
-	err := o.ScribeOptions.Complete()
-	if err != nil {
+func (o *SetupReplicationOptions) Complete() error {
+	if err := o.RepOpts.Complete(); err != nil {
 		return err
 	}
-	o.Namespace = o.ScribeOptions.SourceNamespace
 	if len(o.Name) == 0 {
-		o.Name = o.Namespace + "-source"
+		o.Name = o.RepOpts.Source.Namespace + "-source"
 	}
-	klog.V(2).Infof("replication source %s will be created in %s namespace", o.Name, o.Namespace)
+	if len(o.DestOpts.Name) == 0 {
+		o.DestOpts.Name = fmt.Sprintf("%s-destination", o.RepOpts.Dest.Namespace)
+	}
+	if len(o.DestOpts.StorageClass) == 0 {
+		o.DestOpts.StorageClass = destPVCStorageClass
+	}
+	if err := o.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 
 //nolint:lll
-// Validate validates ReplicationSource options.
-func (o *SourceOptions) Validate() error {
+func (o *SetupReplicationOptions) Validate() error {
 	if len(o.CopyMethod) == 0 {
-		return fmt.Errorf("must provide --copy-method; one of 'None|Clone|Snapshot'")
+		return fmt.Errorf("must provide --source-copy-method; one of 'None|Clone|Snapshot'")
 	}
-	//TODO: FIX THIS to find default secret name, so this won't be required
-	if len(o.SSHKeysSecretOptions.SSHKeysSecret) == 0 {
-		return fmt.Errorf("must provide the name of the secret in ReplicationSource namespace that holds the SSHKeys for connecting to the ReplicationDestination namespace")
+	if len(o.DestOpts.CopyMethod) == 0 {
+		return fmt.Errorf("must provide --dest-copy-method; one of 'None|Clone|Snapshot'")
+	}
+	if len(o.DestOpts.Capacity) == 0 && len(o.DestOpts.DestPVC) == 0 {
+		return fmt.Errorf("must either provide --dest-capacity & --dest-access-mode OR --dest-pvc")
+	}
+	if len(o.DestOpts.AccessMode) == 0 && len(o.DestOpts.DestPVC) == 0 {
+		return fmt.Errorf("must either provide --dest-capacity & --dest-access-mode OR --dest-pvc")
 	}
 	return nil
 }
 
-func (o *SourceOptions) commonOptions() (*CommonOptions, error) {
-	repOpts := &ReplicationOptions{
+func (o *SetupReplicationOptions) sourceCommonOptions() error {
+	sharedOpts := &sharedOptions{
 		CopyMethod:              o.CopyMethod,
 		Capacity:                o.Capacity,
-		StorageClassName:        o.StorageClassName,
+		StorageClass:            o.StorageClass,
 		AccessMode:              o.AccessMode,
-		Address:                 o.Address,
 		VolumeSnapshotClassName: o.VolumeSnapshotClassName,
-		PVC:                     o.PVC,
 		SSHUser:                 o.SSHUser,
 		ServiceType:             o.ServiceType,
 		Port:                    o.Port,
-		Path:                    o.Path,
 		RcloneConfig:            o.RcloneConfig,
 		Provider:                o.Provider,
 		ProviderParameters:      o.ProviderParameters,
 	}
-	return repOpts.GetCommonOptions()
+	return o.getCommonOptions(sharedOpts, "source")
 }
 
-// CreateReplicationSource creates a ReplicationSource resource
-func (o *SourceOptions) CreateReplicationSource() error {
-	c, err := o.commonOptions()
+func (o *SetupReplicationOptions) destCommonOptions() error {
+	sharedOpts := &sharedOptions{
+		CopyMethod:              o.DestOpts.CopyMethod,
+		Capacity:                o.DestOpts.Capacity,
+		StorageClass:            o.DestOpts.StorageClass,
+		AccessMode:              o.DestOpts.AccessMode,
+		VolumeSnapshotClassName: o.DestOpts.VolumeSnapshotClassName,
+		SSHUser:                 o.DestOpts.SSHUser,
+		ServiceType:             o.DestOpts.ServiceType,
+		Port:                    o.DestOpts.Port,
+		RcloneConfig:            o.DestOpts.RcloneConfig,
+		Provider:                o.DestOpts.Provider,
+		ProviderParameters:      o.DestOpts.ProviderParameters,
+	}
+	return o.getCommonOptions(sharedOpts, "dest")
+}
+
+// StartReplication does the following:
+// 1) Create ReplicationDestination
+// 2) Create DestinationPVC (if not provided)
+// 3) Create ReplicationSource
+func (o *SetupReplicationOptions) StartReplication() error {
+	ctx := context.Background()
+	if err := o.sourceCommonOptions(); err != nil {
+		return err
+	}
+	if err := o.destCommonOptions(); err != nil {
+		return err
+	}
+	if err := o.CreateDestination(ctx); err != nil {
+		return err
+	}
+
+	klog.Infof("Extracting ReplicationDestination RSync address")
+	repDest := &scribev1alpha1.ReplicationDestination{}
+	nsName := types.NamespacedName{
+		Namespace: o.RepOpts.Dest.Namespace,
+		Name:      o.DestOpts.Name,
+	}
+	var address *string
+	err := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+		err := o.RepOpts.Dest.Client.Get(ctx, nsName, repDest)
+		if err != nil {
+			return false, err
+		}
+		if repDest.Status == nil {
+			return false, nil
+		}
+		if repDest.Status.Rsync.Address == nil {
+			klog.Infof("Waiting for ReplicationDestination %s RSync address to populate")
+			return false, nil
+		}
+		klog.Infof("Found ReplicationDestination RSync Address: %s", *repDest.Status.Rsync.Address)
+		address = repDest.Status.Rsync.Address
+		return true, nil
+	})
 	if err != nil {
 		return err
 	}
+
 	var sshKeysSecret *string
 	switch {
 	case len(o.SSHKeysSecretOptions.SSHKeysSecret) > 0:
 		sshKeysSecret = &o.SSHKeysSecretOptions.SSHKeysSecret
 	default:
-		sshKeysSecret = nil
+		s := fmt.Sprintf("scribe-rsync-dest-src-%s", repDest.Name)
+		sshKeysSecret = &s
 	}
+	sshSecret := &corev1.Secret{}
+	nsName = types.NamespacedName{
+		Namespace: o.RepOpts.Dest.Namespace,
+		Name:      *sshKeysSecret,
+	}
+	err = o.RepOpts.Dest.Client.Get(ctx, nsName, sshSecret)
+	if err != nil {
+		return fmt.Errorf("error retrieving destination sshSecret %s failed to sync secret", *sshKeysSecret, o.RepOpts.Source.Namespace)
+	}
+	klog.Infof("Found destination SSH secret %s, namespace %s", *sshKeysSecret, o.RepOpts.Dest.Namespace)
+	sshSecret = &corev1.Secret{}
+	nsName = types.NamespacedName{
+		Namespace: o.RepOpts.Source.Namespace,
+		Name:      *sshKeysSecret,
+	}
+	klog.Infof("Ensuring source SSH secret %s exists in namespace %s", *sshKeysSecret, o.RepOpts.Source.Namespace)
+	err = o.RepOpts.Dest.Client.Get(ctx, nsName, sshSecret)
+	if err != nil {
+		if !kerrs.IsNotFound(err) {
+			return err
+		}
+		opts := &SSHKeysSecretOptions{
+			RepOpts:       o.RepOpts,
+			SSHKeysSecret: *sshKeysSecret,
+		}
+		err = opts.SyncSSHSecret()
+		if err != nil {
+			return err
+		}
+	}
+
 	triggerSpec := &scribev1alpha1.ReplicationSourceTriggerSpec{
 		Schedule: &o.Schedule,
 	}
@@ -214,24 +309,24 @@ func (o *SourceOptions) CreateReplicationSource() error {
 	}
 	rsyncSpec := &scribev1alpha1.ReplicationSourceRsyncSpec{
 		ReplicationSourceVolumeOptions: scribev1alpha1.ReplicationSourceVolumeOptions{
-			CopyMethod:              c.CopyMethod,
-			Capacity:                c.Capacity,
-			StorageClassName:        c.StorageClassName,
-			AccessModes:             c.AccessModes,
-			VolumeSnapshotClassName: c.VolumeSnapClassName,
+			CopyMethod:              o.RepOpts.Source.CopyMethod,
+			Capacity:                &o.RepOpts.Source.Capacity,
+			StorageClassName:        o.RepOpts.Source.StorageClass,
+			AccessModes:             o.RepOpts.Source.AccessModes,
+			VolumeSnapshotClassName: o.RepOpts.Source.VolumeSnapClassName,
 		},
 		SSHKeys:     sshKeysSecret,
-		ServiceType: &c.ServiceType,
-		Address:     c.Address,
-		Port:        c.Port,
-		Path:        c.Path,
-		SSHUser:     c.SSHUser,
+		ServiceType: &o.RepOpts.Source.ServiceType,
+		Address:     address,
+		Port:        o.RepOpts.Source.Port,
+		Path:        repDest.Spec.Rsync.Path,
+		SSHUser:     o.RepOpts.Source.SSHUser,
 	}
 	var externalSpec *scribev1alpha1.ReplicationSourceExternalSpec
-	if len(o.Provider) > 0 && c.Parameters != nil {
+	if len(o.RepOpts.Source.Provider) > 0 && o.RepOpts.Source.Parameters != nil {
 		externalSpec = &scribev1alpha1.ReplicationSourceExternalSpec{
-			Provider:   o.Provider,
-			Parameters: c.Parameters,
+			Provider:   o.RepOpts.Source.Provider,
+			Parameters: o.RepOpts.Source.Parameters,
 		}
 	}
 	rs := &scribev1alpha1.ReplicationSource{
@@ -241,18 +336,182 @@ func (o *SourceOptions) CreateReplicationSource() error {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      o.Name,
-			Namespace: o.Namespace,
+			Namespace: o.RepOpts.Source.Namespace,
 		},
 		Spec: scribev1alpha1.ReplicationSourceSpec{
-			SourcePVC: *c.PVC,
+			SourcePVC: o.SourcePVC,
 			Trigger:   triggerSpec,
 			Rsync:     rsyncSpec,
 			External:  externalSpec,
 		},
 	}
-	if err := o.ScribeOptions.SourceClient.Create(context.TODO(), rs); err != nil {
+	if err := o.RepOpts.Source.Client.Create(ctx, rs); err != nil {
 		return err
 	}
-	klog.V(0).Infof("ReplicationSource %s created in namespace %s", o.Name, o.Namespace)
+	klog.Infof("ReplicationSource %s created in namespace %s", o.Name, o.RepOpts.Source.Namespace)
+	return nil
+}
+
+// NameDestinationPVC returns the name that will be given to the destination PVC
+func (o *SetupReplicationOptions) NameDestinationPVC(ctx context.Context) (string, error) {
+	// can't have 2 PVCs in same ns, same name
+	destPVCName := o.DestOpts.DestPVC
+	if len(destPVCName) == 0 {
+		destPVCName = o.SourcePVC
+	}
+
+	// check for PVC of same name in dest location. If so, then tag the new PVC to avoid name conflict
+	destPVCExists := false
+	destPVC := &corev1.PersistentVolumeClaim{}
+	nsName := types.NamespacedName{
+		Namespace: o.RepOpts.Dest.Namespace,
+		Name:      destPVCName,
+	}
+	if err := o.RepOpts.Dest.Client.Get(ctx, nsName, destPVC); err == nil {
+		destPVCExists = true
+	} else {
+		if !kerrs.IsNotFound(err) {
+			return "", err
+		}
+	}
+
+	if destPVCExists || (o.SourcePVC == o.DestOpts.DestPVC && o.RepOpts.Source.Namespace == o.RepOpts.Dest.Namespace) {
+		t := time.Now().Format("2006-01-02T15:04:05")
+		tag := strings.ReplaceAll(t, ":", "-")
+		destPVCName = strings.ToLower(fmt.Sprintf("%s-%s", o.SourcePVC, tag))
+	}
+	return destPVCName, nil
+}
+
+func (o *SetupReplicationOptions) GetSourcePVC(ctx context.Context) (*corev1.PersistentVolumeClaim, error) {
+	srcPVC := &corev1.PersistentVolumeClaim{}
+	nsName := types.NamespacedName{
+		Namespace: o.RepOpts.Source.Namespace,
+		Name:      o.SourcePVC,
+	}
+	if err := o.RepOpts.Source.Client.Get(ctx, nsName, srcPVC); err != nil {
+		return nil, err
+	}
+	return srcPVC, nil
+}
+
+// CreateDestinationPVCFromSource creates PVC in destination namespace synced from source PVC
+func (o *SetupReplicationOptions) CreateDestinationPVCFromSource(ctx context.Context, latestImage *corev1.TypedLocalObjectReference, destPVCName string) error {
+	srcPVC, err := o.GetSourcePVC(ctx)
+	if err != nil {
+		return err
+	}
+	newPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      destPVCName,
+			Namespace: o.RepOpts.Dest.Namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: o.RepOpts.Dest.StorageClass,
+			AccessModes:      srcPVC.Spec.AccessModes,
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: o.RepOpts.Dest.Capacity,
+				},
+			},
+			Selector: srcPVC.Spec.Selector,
+		},
+	}
+
+	// If ReplicationDestination is copy method Snapshot, add the DataSource
+	// from the ReplicationDestination LatestImage
+	if latestImage != nil {
+		newPVC.Spec.DataSource = latestImage
+	}
+
+	klog.V(2).Infof("Creating PVC %s in destination namespace %s", destPVCName, o.RepOpts.Dest.Namespace)
+	if err := o.RepOpts.Dest.Client.Create(ctx, newPVC); err != nil {
+		return err
+	}
+	klog.Infof("PVC %s created in destination namespace: %s", destPVCName, o.RepOpts.Dest.Namespace)
+	return nil
+}
+
+// CreateDestination creates a ReplicationDestination resource
+// along with a destination PVC if copyMethod "None"
+func (o *SetupReplicationOptions) CreateDestination(ctx context.Context) error {
+	destPVCName, err := o.NameDestinationPVC(ctx)
+	if err != nil {
+		return err
+	}
+	if o.RepOpts.Dest.CopyMethod == scribev1alpha1.CopyMethodNone {
+		if err := o.CreateDestinationPVCFromSource(ctx, nil, destPVCName); err != nil {
+			return err
+		}
+	}
+	var sshKeysSecret *string
+	switch {
+	case len(o.SSHKeysSecretOptions.SSHKeysSecret) > 0:
+		sshKeysSecret = &o.SSHKeysSecretOptions.SSHKeysSecret
+	default:
+		sshKeysSecret = nil
+	}
+	triggerSpec := &scribev1alpha1.ReplicationDestinationTriggerSpec{
+		Schedule: &o.DestOpts.Schedule,
+	}
+	if len(o.DestOpts.Schedule) == 0 {
+		triggerSpec = nil
+	}
+	address := &o.DestOpts.Address
+	if len(o.DestOpts.Address) == 0 {
+		address = nil
+	}
+	path := &o.DestOpts.Path
+	if len(o.DestOpts.Path) == 0 {
+		path = nil
+	}
+
+	rsyncSpec := &scribev1alpha1.ReplicationDestinationRsyncSpec{
+		ReplicationDestinationVolumeOptions: scribev1alpha1.ReplicationDestinationVolumeOptions{
+			CopyMethod:              o.RepOpts.Dest.CopyMethod,
+			Capacity:                &o.RepOpts.Dest.Capacity,
+			StorageClassName:        o.RepOpts.Dest.StorageClass,
+			AccessModes:             o.RepOpts.Dest.AccessModes,
+			VolumeSnapshotClassName: o.RepOpts.Dest.VolumeSnapClassName,
+			DestinationPVC:          &destPVCName,
+		},
+		SSHKeys:     sshKeysSecret,
+		SSHUser:     o.RepOpts.Dest.SSHUser,
+		Address:     address,
+		ServiceType: &o.RepOpts.Dest.ServiceType,
+		Port:        o.RepOpts.Dest.Port,
+		Path:        path,
+	}
+
+	if o.RepOpts.Dest.CopyMethod != scribev1alpha1.CopyMethodNone && len(o.DestOpts.DestPVC) == 0 {
+		rsyncSpec.ReplicationDestinationVolumeOptions.DestinationPVC = nil
+	}
+	var externalSpec *scribev1alpha1.ReplicationDestinationExternalSpec
+	if len(o.RepOpts.Dest.Provider) > 0 && o.RepOpts.Dest.Parameters != nil {
+		externalSpec = &scribev1alpha1.ReplicationDestinationExternalSpec{
+			Provider:   o.RepOpts.Dest.Provider,
+			Parameters: o.RepOpts.Dest.Parameters,
+		}
+	}
+	rd := &scribev1alpha1.ReplicationDestination{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "scribe.backube/v1alpha1",
+			Kind:       "ReplicationDestination",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      o.DestOpts.Name,
+			Namespace: o.RepOpts.Dest.Namespace,
+		},
+		Spec: scribev1alpha1.ReplicationDestinationSpec{
+			Trigger:  triggerSpec,
+			Rsync:    rsyncSpec,
+			External: externalSpec,
+		},
+	}
+	klog.V(2).Infof("Creating ReplicationDestination %s in namespace %s", o.DestOpts.Name, o.RepOpts.Dest.Namespace)
+	if err := o.RepOpts.Dest.Client.Create(ctx, rd); err != nil {
+		return err
+	}
+	klog.V(0).Infof("ReplicationDestination %s created in namespace %s", o.DestOpts.Name, o.RepOpts.Dest.Namespace)
 	return nil
 }

--- a/pkg/cmd/sync_secret.go
+++ b/pkg/cmd/sync_secret.go
@@ -4,96 +4,24 @@ import (
 	"context"
 	"fmt"
 
-	scribev1alpha1 "github.com/backube/scribe/api/v1alpha1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
 	kcmdutil "k8s.io/kubectl/pkg/cmd/util"
-	"k8s.io/kubectl/pkg/util/i18n"
-	"k8s.io/kubectl/pkg/util/templates"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-var (
-	scribeSyncSSHSecretLong = templates.LongDesc(`
-        Scribe is a command line tool for a scribe operator running in a Kubernetes cluster.
-		Scribe asynchronously replicates Kubernetes persistent volumes between clusters or namespaces
-		using rsync, rclone, or restic. Scribe uses a ReplicationDestination and a ReplicationSource
-		to replicate a volume. Data will be synced according to the configured sync schedule.
-`)
-	scribeSyncSSHSecretExample = templates.Examples(`
-	    # Copy the SSH secret from the ReplicationDestination namespace to the ReplicationSource namespace.
-		# Secret will be copied from namespace 'dest' to namespace 'source'. Config file 'scribe-config'
-		# in current directory with dest, source flag values.
-		$ scribe sync-ssh-secret
-
-		# Copy the SSH secret from the ReplicationDestination namespace to the ReplicationSource namespace.
-		# Secret will be copied from namespace 'dest' to namespace 'source'.
-		$ scribe sync-ssh-secret --dest-namespace=dest --source-namespace=source
-
-		# Copy the SSH secret from the ReplicationDestination namespace in one cluster 
-		# to the ReplicationSource namespace in another clutser.
-		# Secret will be copied from clustername 'destcluster' context 'destuser' namespace 'dest'
-		# to context 'sourceuser' clustername 'api-test-com:6443' namespace 'source'.
-		$ scribe sync-ssh-secret \
-		    --dest-namespace=dest \
-		    --source-namespace=source \
-			--dest-kube-context=destuser \
-			--dest-clustername=destcluster \
-			--source-kube-context=sourceuser \
-			--source-clustername=api-test-com:6443
-    `)
 )
 
 type SSHKeysSecretOptions struct {
-	ScribeOptions ScribeOptions
+	Config        Config
+	RepOpts       ReplicationOptions
 	SSHKeysSecret string
-
-	genericclioptions.IOStreams
-}
-
-func NewCmdScribeSyncSSHSecret(streams genericclioptions.IOStreams) *cobra.Command {
-	v := viper.New()
-	o := NewSSHKeysSecretOptions(streams)
-	cmd := &cobra.Command{
-		Use:     "sync-ssh-secret [OPTIONS]",
-		Short:   i18n.T("Copy the SSH secret for rsync between namespaces and/or clusters."),
-		Long:    fmt.Sprint(scribeSyncSSHSecretLong),
-		Example: fmt.Sprint(scribeSyncSSHSecretExample),
-		Version: ScribeVersion,
-		Run: func(cmd *cobra.Command, args []string) {
-			kcmdutil.CheckErr(o.Complete())
-			kcmdutil.CheckErr(o.SyncSSHSecret())
-		},
-	}
-	kcmdutil.CheckErr(o.ScribeOptions.Bind(cmd, v))
-	kcmdutil.CheckErr(o.Bind(cmd, v))
-
-	return cmd
-}
-
-func (o *SSHKeysSecretOptions) Bind(cmd *cobra.Command, v *viper.Viper) error {
-	// config file in current directory
-	// TODO: where to look for config file
-	v.SetConfigName(scribeConfig)
-	v.AddConfigPath(".")
-	v.SetConfigType("yaml")
-	if err := v.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			return err
-		}
-	}
-	o.bindFlags(cmd, v)
-	return nil
 }
 
 //nolint:lll
-func (o *SSHKeysSecretOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) {
+func (o *SSHKeysSecretOptions) Bind(cmd *cobra.Command, v *viper.Viper) {
 	flags := cmd.Flags()
 	flags.StringVar(&o.SSHKeysSecret, "ssh-keys-secret", o.SSHKeysSecret, "name of existing valid SSHKeys secret for authentication. If not set, the dest-src SSHKey secret-name will be used from destinationlocation.")
 
@@ -105,57 +33,28 @@ func (o *SSHKeysSecretOptions) bindFlags(cmd *cobra.Command, v *viper.Viper) {
 	})
 }
 
-func NewSSHKeysSecretOptions(streams genericclioptions.IOStreams) *SSHKeysSecretOptions {
-	return &SSHKeysSecretOptions{
-		IOStreams: streams,
-	}
-}
-
-// Complete takes the cmd and infers options.
-func (o *SSHKeysSecretOptions) Complete() error {
-	ctx := context.Background()
-	err := o.ScribeOptions.Complete()
-	if err != nil {
-		return err
-	}
-	repDests := &scribev1alpha1.ReplicationDestinationList{}
-	opts := []client.ListOption{
-		client.InNamespace(o.ScribeOptions.DestNamespace),
-	}
-
-	err = o.ScribeOptions.DestinationClient.List(ctx, repDests, opts...)
-	if err != nil {
-		return err
-	}
-
-	if len(o.SSHKeysSecret) == 0 {
-		o.SSHKeysSecret = "scribe-rsync-dest-src-" + repDests.Items[0].Name
-	}
-	return nil
-}
-
 func (o *SSHKeysSecretOptions) SyncSSHSecret() error {
 	ctx := context.Background()
 	originalSecret := &corev1.Secret{}
 	nsName := types.NamespacedName{
-		Namespace: o.ScribeOptions.DestNamespace,
+		Namespace: o.RepOpts.Dest.Namespace,
 		Name:      o.SSHKeysSecret,
 	}
-	err := o.ScribeOptions.DestinationClient.Get(ctx, nsName, originalSecret)
+	err := o.RepOpts.Dest.Client.Get(ctx, nsName, originalSecret)
 	if err != nil {
 		return err
 	}
 	newSecret := originalSecret.DeepCopy()
 	newSecret.ObjectMeta = metav1.ObjectMeta{
 		Name:            originalSecret.ObjectMeta.Name,
-		Namespace:       o.ScribeOptions.SourceNamespace,
+		Namespace:       o.RepOpts.Source.Namespace,
 		OwnerReferences: nil,
 	}
 
-	err = o.ScribeOptions.SourceClient.Create(ctx, newSecret)
+	err = o.RepOpts.Source.Client.Create(ctx, newSecret)
 	if err != nil {
 		return err
 	}
-	klog.Infof("secret %s created in namespace %s", o.SSHKeysSecret, o.ScribeOptions.SourceNamespace)
+	klog.Infof("Secret %s created in namespace %s", o.SSHKeysSecret, o.RepOpts.Source.Namespace)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Sally O'Malley <somalley@redhat.com>

**Describe what this PR does**
Enables the following flow (if multi-cluster, add source & dest contexts, clusternames to the scribe config):
```
1) source application is running with a source PVC
2) "hm, I'd like to replicate this and maybe change the storage class"
3) "I'll use scribe!"
```
```
$ cat config.yaml
---
dest-access-mode: ReadWriteOnce
dest-namespace: dest
dest-copy-method: Snapshot
source-pvc: mysql-pv-claim
source-copy-method: Snapshot
source-namespace: source
dest-storage-class: gp2-csi
dest-service-type: ClusterIP
source-service-type: ClusterIP
```
```
$ oc scribe start-replication  (creates repdest, repsource, ssh keys in source -if copyMethod=None, a destPVC is created)
$ oc scribe set-replication     (one last sync, then pause with manual trigger, and a dest PVC is created w/ that snapshot)
```
4) "I'll now edit my destination deployment to reference the new destination PVC with the synced data"
5) "I've verified my destination application is up-to-date, I might want to delete the stale PVC from previous syncs, or maybe I'll collect them here"
6) "Time to sync data again!
```
$ oc scribe continue-replication (removes the manual trigger from repSource)
$ oc scribe set-replication (update deployment with new destPVC, stale PVCs accumulate - scribe will not prune those)
$ oc scribe continue, set replication as many times as desired. (with "Snapshot", but with "None" have to remove-replication each sync)
```
"I'm all done, I'm going to remove this replication."
```
$ oc scribe remove-replication (removes repSource, repDest, synced sshSecret - does not prune any PVCs) 
```
TODO:
* unit-tests

**Related issues:**
https://github.com/backube/scribe/issues/148