### PR TITLE
Restic secret

### DIFF
--- a/controllers/replicationdestination_controller.go
+++ b/controllers/replicationdestination_controller.go
@@ -954,6 +954,8 @@ func (r *rcloneDestReconciler) validateRcloneSpec(l logr.Logger) (bool, error) {
 	l.V(1).Info("Rclone config validation complete.")
 	return true, nil
 }
+
+//nolint:dupl
 func (r *resticDestReconciler) validateResticSpec(l logr.Logger) (bool, error) {
 	var err error
 	var result bool = true
@@ -967,9 +969,12 @@ func (r *resticDestReconciler) validateResticSpec(l logr.Logger) (bool, error) {
 		foundSecret := &corev1.Secret{}
 		secretNotFoundErr := r.Client.Get(r.Ctx,
 			types.NamespacedName{
-				Name: resticSecretName, Namespace: r.Instance.Namespace}, foundSecret)
+				Name:      r.Instance.Spec.Restic.Repository,
+				Namespace: r.Instance.Namespace,
+			}, foundSecret)
 		if secretNotFoundErr != nil {
-			l.Error(err, "restic-config secret not found.")
+			l.Error(err, "restic repository secret not found.",
+				"repository", r.Instance.Spec.Restic.Repository)
 			result = false
 			err = secretNotFoundErr
 		} else {

--- a/controllers/replicationsource_controller.go
+++ b/controllers/replicationsource_controller.go
@@ -992,6 +992,7 @@ func (r *rcloneSrcReconciler) validateRcloneSpec(l logr.Logger) (bool, error) {
 	return true, nil
 }
 
+//nolint:dupl
 func (r *resticSrcReconciler) validateResticSpec(l logr.Logger) (bool, error) {
 	var err error
 	var result bool = true
@@ -1003,11 +1004,14 @@ func (r *resticSrcReconciler) validateResticSpec(l logr.Logger) (bool, error) {
 	if err == nil {
 		// get secret from cluster
 		foundSecret := &corev1.Secret{}
-		secretNotFoundErr := r.Client.Get(context.TODO(),
+		secretNotFoundErr := r.Client.Get(r.Ctx,
 			types.NamespacedName{
-				Name: resticSecretName, Namespace: r.Instance.Namespace}, foundSecret)
+				Name:      r.Instance.Spec.Restic.Repository,
+				Namespace: r.Instance.Namespace,
+			}, foundSecret)
 		if secretNotFoundErr != nil {
-			l.Error(err, "restic-config secret not found.")
+			l.Error(err, "restic repository secret not found.",
+				"repository", r.Instance.Spec.Restic.Repository)
 			result = false
 			err = secretNotFoundErr
 		} else {

--- a/controllers/rsync_common.go
+++ b/controllers/rsync_common.go
@@ -39,9 +39,7 @@ import (
 const (
 	dataVolumeName = "data"
 	rcloneSecret   = "rclone-secret"
-	//nolint
-	resticSecretName = "restic-config"
-	resticCache      = "cache"
+	resticCache    = "cache"
 )
 
 type rsyncSvcDescription struct {

--- a/hack/run-in-kind.sh
+++ b/hack/run-in-kind.sh
@@ -16,7 +16,12 @@ make -C mover-rsync image
 # We are using a special tag that should never be pushed to a repo so that it's
 # obvious if we try to run a container other than these intended ones.
 KIND_TAG=local-build
-IMAGES=("quay.io/backube/scribe" "quay.io/backube/scribe-mover-rclone" "quay.io/backube/scribe-mover-rsync")
+IMAGES=(
+        "quay.io/backube/scribe"
+        "quay.io/backube/scribe-mover-rclone"
+        "quay.io/backube/scribe-mover-restic"
+        "quay.io/backube/scribe-mover-rsync"
+)
 for i in "${IMAGES[@]}"; do
     docker tag "${i}:latest" "${i}:${KIND_TAG}"
     kind load docker-image "${i}:${KIND_TAG}"


### PR DESCRIPTION
**Describe what this PR does**
The restic repo field in the CR was being ignored. This ensures the name of the restic repo secret is taken from the CR field instead of using a hardcoded name.

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
