### PR TITLE
Add restic e2e test

### DIFF
--- a/test-kuttl/e2e/operator-running/00-assert.yaml
+++ b/test-kuttl/e2e/operator-running/00-assert.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: scribe-ghaction
-  namespace: scribe-system
-status:
-  readyReplicas: 1

--- a/test-kuttl/e2e/simple-restic/00-create-restic-secret.sh
+++ b/test-kuttl/e2e/simple-restic/00-create-restic-secret.sh
@@ -1,0 +1,20 @@
+#! /bin/bash
+
+set -e -o pipefail
+
+MINIO_ACCESS_KEY=$(kubectl get secret --namespace minio minio -o jsonpath="{.data.access-key}" | base64 --decode)
+MINIO_SECRET_KEY=$(kubectl get secret --namespace minio minio -o jsonpath="{.data.secret-key}" | base64 --decode)
+
+kubectl create -n "$NAMESPACE" -f - <<EOF
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: restic-repo
+type: Opaque
+stringData:
+  RESTIC_REPOSITORY: s3:http://minio.minio.svc.cluster.local:9000/restic-bucket
+  RESTIC_PASSWORD: ThisIsTheResticPassword
+  AWS_ACCESS_KEY_ID: ${MINIO_ACCESS_KEY}
+  AWS_SECRET_ACCESS_KEY: ${MINIO_SECRET_KEY}
+EOF

--- a/test-kuttl/e2e/simple-restic/00-create-restic-secret.yaml
+++ b/test-kuttl/e2e/simple-restic/00-create-restic-secret.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - timeout: 90
+    command: ./00-create-restic-secret.sh

--- a/test-kuttl/e2e/simple-restic/05-assert.yaml
+++ b/test-kuttl/e2e/simple-restic/05-assert.yaml
@@ -1,0 +1,7 @@
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: source
+status:
+  phase: Running

--- a/test-kuttl/e2e/simple-restic/05-populate-source-volume.yaml
+++ b/test-kuttl/e2e/simple-restic/05-populate-source-volume.yaml
@@ -1,0 +1,30 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: data-source
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: source
+spec:
+  containers:
+    - name: busybox
+      image: busybox
+      command: ["/bin/sh", "-c"]
+      args: ["echo 'somedata' > /mnt/datafile; sleep 99999"]
+      volumeMounts:
+        - name: data
+          mountPath: "/mnt"
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: data-source

--- a/test-kuttl/e2e/simple-restic/10-assert.yaml
+++ b/test-kuttl/e2e/simple-restic/10-assert.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+
+---
+kind: ReplicationSource
+apiVersion: scribe.backube/v1alpha1
+metadata:
+  name: source
+status:
+  lastManualSync: once

--- a/test-kuttl/e2e/simple-restic/10-create-source.yaml
+++ b/test-kuttl/e2e/simple-restic/10-create-source.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: scribe.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: source
+spec:
+  sourcePVC: data-source
+  trigger:
+    manual: once
+  restic:
+    pruneIntervalDays: 1
+    repository: restic-repo
+    retain:
+      hourly: 3
+      daily: 2
+      monthly: 1
+    copyMethod: Clone
+    cacheCapacity: 1Gi

--- a/test-kuttl/e2e/simple-restic/15-assert.yaml
+++ b/test-kuttl/e2e/simple-restic/15-assert.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 120
+
+---
+kind: ReplicationDestination
+apiVersion: scribe.backube/v1alpha1
+metadata:
+  name: restore
+status:
+  lastManualSync: restore-once

--- a/test-kuttl/e2e/simple-restic/15-restore.yaml
+++ b/test-kuttl/e2e/simple-restic/15-restore.yaml
@@ -1,0 +1,25 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: data-dest
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: scribe.backube/v1alpha1
+kind: ReplicationDestination
+metadata:
+  name: restore
+spec:
+  trigger:
+    manual: restore-once
+  restic:
+    repository: restic-repo
+    destinationPVC: data-dest
+    copyMethod: None
+    cacheCapacity: 1Gi

--- a/test-kuttl/e2e/simple-restic/20-assert.yaml
+++ b/test-kuttl/e2e/simple-restic/20-assert.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 90
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify
+status:
+  succeeded: 1

--- a/test-kuttl/e2e/simple-restic/20-verify-data.yaml
+++ b/test-kuttl/e2e/simple-restic/20-verify-data.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: verify
+spec:
+  template:
+    spec:
+      containers:
+        - name: busybox
+          image: busybox
+          command: ["/bin/sh", "-c"]
+          args: ["diff -rs /mnt /mnt2"]
+          volumeMounts:
+            - name: data-src
+              mountPath: "/mnt"
+            - name: data-dest
+              mountPath: "/mnt2"
+      volumes:
+        - name: data-dest
+          persistentVolumeClaim:
+            claimName: data-dest
+        - name: data-src
+          persistentVolumeClaim:
+            claimName: data-source
+      restartPolicy: Never


### PR DESCRIPTION
**Describe what this PR does**
Adds a simple e2e for restic just like we have for rclone and rsync

**Is there anything that requires special attention?**
This also removes the "operator running" e2e... If the operator isn't running, none of the tests will pass.

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
