### PR TITLE
Update versions & matrix build

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -52,8 +52,8 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Test
-        run: make test
+      - name: Build operator container
+        run: make docker-build IMG=${OPERATOR_IMAGE}
 
       - name: Upload test coverage
         uses: codecov/codecov-action@v1
@@ -61,9 +61,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./cover.out
           fail_ci_if_error: true
-
-      - name: Build operator container
-        run: make docker-build IMG=${OPERATOR_IMAGE}
 
       - name: Export container image
         run: docker save -o /tmp/image.tar ${OPERATOR_IMAGE}

--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -12,8 +12,8 @@ on:  # yamllint disable-line rule:truthy
     - cron: "15 4 * * 1"  # 4:15 every Monday
 
 env:
-  GO_VERSION: "1.15"
-  KIND_VERSION: "0.9.0"
+  GO_VERSION: "1.16"
+  KIND_VERSION: "0.11.0"
   GO111MODULE: "on"
   OPERATOR_IMAGE: "quay.io/backube/scribe"
   RCLONE_IMAGE: "quay.io/backube/scribe-mover-rclone"
@@ -153,7 +153,10 @@ jobs:
         # There must be kindest/node images for these versions
         # See: https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
         # Or: skopeo list-tags docker://kindest/node
-        KUBERNETES_VERSIONS: ["1.20.2"]
+        KUBERNETES_VERSIONS:
+          - "1.19.7"  # OCP 4.6
+          - "1.20.7"  # OCP 4.7
+          - "1.21.1"  # OCP 4.8
     env:
       KUBECONFIG: /tmp/kubeconfig
       KUBERNETES_VERSION: ${{ matrix.KUBERNETES_VERSIONS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILDDATE := $(shell date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
 # Helper software versions
 GOLANGCI_VERSION := v1.31.0
 HELM_VERSION := v3.5.0
-OPERATOR_SDK_VERSION := v1.7.2
+OPERATOR_SDK_VERSION := v1.8.0
 KUTTL_VERSION := 0.7.2
 
 # CHANNELS define the bundle channels used in the bundle.

--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 # Possible versions:
 # https://hub.docker.com/r/kindest/node/tags?page=1&ordering=name
 # skopeo inspect docker://kindest/node:v1.17.0 | jq .RepoTags
-KUBE_VERSION="${1:-1.20.2}"
+KUBE_VERSION="${1:-1.21.1}"
 
 # Determine the Kube minor version
 [[ "${KUBE_VERSION}" =~ ^[0-9]+\.([0-9]+) ]] && KUBE_MINOR="${BASH_REMATCH[1]}" || exit 1


### PR DESCRIPTION
**Describe what this PR does**
- Upgrade to golang 1.16
- Upgrade kind to 0.11.0
- Matrix CI on kube 1.19-1.21
- Upgrade operator-sdk to 1.8.0

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixed #158