### PR TITLE
Fix access modes

### DIFF
--- a/examples/scribe_v1alpha1_replicationdestination_rclone.yaml
+++ b/examples/scribe_v1alpha1_replicationdestination_rclone.yaml
@@ -12,5 +12,5 @@ spec:
     rcloneDestPath: "scribe-test-bucket"
     rcloneConfig: "rclone-secret"
     copyMethod: Snapshot
-    accessModes: [ReadWriteMany]
+    accessModes: [ReadWriteOnce]
     capacity: 2Gi


### PR DESCRIPTION
Switch from `ReadWriteMany` to `ReadWriteOnce` since all the documentation refers to block devices storage types (AWS/RWO & GCE/RWO-ROM).

It'd work if you have a FileSystem/RWM storage provider in your cluster but it is not a common case.