### PR TITLE
Version bumps

### DIFF
--- a/.github/workflows/operator.yml
+++ b/.github/workflows/operator.yml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   GO_VERSION: "1.16"
-  KIND_VERSION: "0.11.0"
+  KIND_VERSION: "0.11.1"
   GO111MODULE: "on"
   OPERATOR_IMAGE: "quay.io/backube/scribe"
   RCLONE_IMAGE: "quay.io/backube/scribe-mover-rclone"

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ VERSION ?= $(shell git describe --tags --dirty --match 'v*' 2> /dev/null || git 
 BUILDDATE := $(shell date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
 
 # Helper software versions
-GOLANGCI_VERSION := v1.40.0
-HELM_VERSION := v3.5.0
-OPERATOR_SDK_VERSION := v1.8.0
-KUTTL_VERSION := 0.7.2
+GOLANGCI_VERSION := v1.41.1
+HELM_VERSION := v3.6.2
+OPERATOR_SDK_VERSION := v1.9.0
+KUTTL_VERSION := 0.10.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "preview,fast,stable")

--- a/mover-rclone/Dockerfile
+++ b/mover-rclone/Dockerfile
@@ -1,13 +1,14 @@
-FROM centos:8
+FROM registry.access.redhat.com/ubi8-minimal
 
-ARG rclone_version=v1.53.2
+ARG rclone_version=v1.55.1
 
-RUN yum update -y && \
-    yum install -y \
-      bash \
+RUN microdnf update -y && \
+    microdnf install -y \
       acl \
+    && \
+    rpm -ivh \
       https://github.com/rclone/rclone/releases/download/${rclone_version}/rclone-${rclone_version}-linux-amd64.rpm \
-    && yum clean all && \
+    && microdnf clean all && \
     rm -rf /var/cache/yum
 
 COPY active.sh \


### PR DESCRIPTION
**Describe what this PR does**
- OperatorSDK - 1.9.0
- golangci-lint - 1.41.1
- rclone - 1.55.1
- helm - 3.6.2
- kuttl - 0.10.0
- kind - 0.11.1

This also switches the rclone mover container to use ubi8-minimal instead of centos8

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
Fixes: #204 