### PR TITLE
Update kuttl e2e to work with OCP on AWS

### DIFF
--- a/hack/setup-kind-cluster.sh
+++ b/hack/setup-kind-cluster.sh
@@ -179,3 +179,6 @@ fi
 
 # Make VSC the cluster default
 kubectl annotate volumesnapshotclass/csi-hostpath-snapclass snapshot.storage.kubernetes.io/is-default-class="true"
+
+# Add a node topology key so that e2e tests can run
+kubectl label nodes --all topology.kubernetes.io/zone=z1

--- a/mover-rclone/active.sh
+++ b/mover-rclone/active.sh
@@ -36,5 +36,6 @@ destination)
     error 1 "unknown value for DIRECTION: ${DIRECTION}"
     ;;
 esac
+sync
 echo "Rclone completed in $(( SECONDS - START_TIME ))s rc=$rc"
 exit "$rc"

--- a/mover-restic/entry.sh
+++ b/mover-restic/entry.sh
@@ -107,5 +107,5 @@ for op in "$@"; do
             ;;
     esac
 done
-
+sync
 echo "=== Done ==="

--- a/mover-rsync/destination.sh
+++ b/mover-rsync/destination.sh
@@ -22,5 +22,6 @@ if [[ -e /tmp/exit_code ]]; then
         CODE="$CODE_IN"
     fi
 fi
+sync
 echo "Exiting... Exit code: $CODE"
 exit "$CODE"

--- a/mover-rsync/source.sh
+++ b/mover-rsync/source.sh
@@ -51,7 +51,7 @@ set +e
 while [[ ${rc} -ne 0 && ${RETRY} -lt ${MAX_RETRIES} ]]
 do
     RETRY=$((RETRY + 1))
-    rsync -aAhHSxz --delete --itemize-changes --info=stats2,misc2 /data/ "root@${DESTINATION_ADDRESS}":. 
+    rsync -aAhHSxz --delete --itemize-changes --info=stats2,misc2 /data/ "root@${DESTINATION_ADDRESS}":.
     rc=$?
     if [[ ${rc} -ne 0 ]]; then
         echo "Syncronization failed. Retrying in ${DELAY} seconds. Retry ${RETRY}/${MAX_RETRIES}."
@@ -61,6 +61,7 @@ do
 done
 set -e
 echo "Rsync completed in $(( SECONDS - START_TIME ))s"
+sync
 if [[ $rc -eq 0 ]]; then
     echo "Synchronization completed successfully. Notifying destination..."
     ssh "root@${DESTINATION_ADDRESS}" shutdown 0

--- a/test-kuttl/e2e/restic-with-manual-trigger/05-populate-source-volume.yaml
+++ b/test-kuttl/e2e/restic-with-manual-trigger/05-populate-source-volume.yaml
@@ -15,15 +15,18 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: source
+  labels:
+    affinity: source
 spec:
   containers:
     - name: busybox
       image: busybox
       command: ["/bin/sh", "-c"]
-      args: ["echo 'somedata' > /mnt/datafile; sleep 99999"]
+      args: ["echo 'somedata' > /mnt/datafile; sync; sleep 99999"]
       volumeMounts:
         - name: data
           mountPath: "/mnt"
+  terminationGracePeriodSeconds: 2
   volumes:
     - name: data
       persistentVolumeClaim:

--- a/test-kuttl/e2e/restic-with-manual-trigger/10-assert.yaml
+++ b/test-kuttl/e2e/restic-with-manual-trigger/10-assert.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 120
+timeout: 180
 
 ---
 kind: ReplicationSource

--- a/test-kuttl/e2e/restic-with-manual-trigger/10-create-source.yaml
+++ b/test-kuttl/e2e/restic-with-manual-trigger/10-create-source.yaml
@@ -14,5 +14,5 @@ spec:
       hourly: 3
       daily: 2
       monthly: 1
-    copyMethod: Clone
+    copyMethod: Snapshot
     cacheCapacity: 1Gi

--- a/test-kuttl/e2e/restic-with-manual-trigger/13-assert.yaml
+++ b/test-kuttl/e2e/restic-with-manual-trigger/13-assert.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 90
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: affinity-setter
+status:
+  succeeded: 1

--- a/test-kuttl/e2e/restic-with-manual-trigger/13-create-restore-volume.yaml
+++ b/test-kuttl/e2e/restic-with-manual-trigger/13-create-restore-volume.yaml
@@ -1,0 +1,42 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: data-dest
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: affinity-setter
+spec:
+  template:
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: affinity
+                    operator: In
+                    values:
+                      - source
+              topologyKey: topology.kubernetes.io/zone
+      containers:
+        - name: busybox
+          image: busybox
+          command: ["/bin/true"]
+          volumeMounts:
+            - name: data-dest
+              mountPath: "/mnt"
+      volumes:
+        - name: data-dest
+          persistentVolumeClaim:
+            claimName: data-dest
+      restartPolicy: Never

--- a/test-kuttl/e2e/restic-with-manual-trigger/15-restore.yaml
+++ b/test-kuttl/e2e/restic-with-manual-trigger/15-restore.yaml
@@ -1,16 +1,4 @@
 ---
-kind: PersistentVolumeClaim
-apiVersion: v1
-metadata:
-  name: data-dest
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
-
----
 apiVersion: scribe.backube/v1alpha1
 kind: ReplicationDestination
 metadata:

--- a/test-kuttl/e2e/restic-with-manual-trigger/17-shutdown-source.yaml
+++ b/test-kuttl/e2e/restic-with-manual-trigger/17-shutdown-source.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: Pod
+  name: source

--- a/test-kuttl/e2e/restic-with-manual-trigger/20-verify-data.yaml
+++ b/test-kuttl/e2e/restic-with-manual-trigger/20-verify-data.yaml
@@ -10,7 +10,7 @@ spec:
         - name: busybox
           image: busybox
           command: ["/bin/sh", "-c"]
-          args: ["diff -rs /mnt /mnt2"]
+          args: ["rm -rf /mnt/lost+found; rm -rf /mnt2/lost+found; diff -rs /mnt /mnt2"]
           volumeMounts:
             - name: data-src
               mountPath: "/mnt"

--- a/test-kuttl/e2e/restic-without-trigger/05-populate-source-volume.yaml
+++ b/test-kuttl/e2e/restic-without-trigger/05-populate-source-volume.yaml
@@ -15,15 +15,18 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: source
+  labels:
+    affinity: source
 spec:
   containers:
     - name: busybox
       image: busybox
       command: ["/bin/sh", "-c"]
-      args: ["echo 'somedata' > /mnt/datafile; sleep 99999"]
+      args: ["echo 'somedata' > /mnt/datafile; sync; sleep 99999"]
       volumeMounts:
         - name: data
           mountPath: "/mnt"
+  terminationGracePeriodSeconds: 2
   volumes:
     - name: data
       persistentVolumeClaim:

--- a/test-kuttl/e2e/restic-without-trigger/10-create-source.yaml
+++ b/test-kuttl/e2e/restic-without-trigger/10-create-source.yaml
@@ -12,5 +12,5 @@ spec:
       hourly: 3
       daily: 2
       monthly: 1
-    copyMethod: Clone
+    copyMethod: Snapshot
     cacheCapacity: 1Gi

--- a/test-kuttl/e2e/simple-rclone/04-populate-source-volume.yaml
+++ b/test-kuttl/e2e/simple-rclone/04-populate-source-volume.yaml
@@ -15,15 +15,18 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: source
+  labels:
+    affinity: source
 spec:
   containers:
     - name: busybox
       image: busybox
       command: ["/bin/sh", "-c"]
-      args: ["echo 'data' > /mnt/datafile; sleep 99999"]
+      args: ["echo 'data' > /mnt/datafile; sync; sleep 99999"]
       volumeMounts:
         - name: data
           mountPath: "/mnt"
+  terminationGracePeriodSeconds: 2
   volumes:
     - name: data
       persistentVolumeClaim:

--- a/test-kuttl/e2e/simple-rclone/11-shutdown-source.yaml
+++ b/test-kuttl/e2e/simple-rclone/11-shutdown-source.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: Pod
+  name: source

--- a/test-kuttl/e2e/simple-rclone/16-verify-data.yaml
+++ b/test-kuttl/e2e/simple-rclone/16-verify-data.yaml
@@ -10,7 +10,7 @@ spec:
         - name: busybox
           image: busybox
           command: ["/bin/sh", "-c"]
-          args: ["diff -rs /mnt /mnt2"]
+          args: ["rm -rf /mnt/lost+found; rm -rf /mnt2/lost+found; diff -rs /mnt /mnt2"]
           volumeMounts:
             - name: data-src
               mountPath: "/mnt"

--- a/test-kuttl/e2e/simple-rsync/05-populate-source-volume.yaml
+++ b/test-kuttl/e2e/simple-rsync/05-populate-source-volume.yaml
@@ -20,10 +20,11 @@ spec:
     - name: busybox
       image: busybox
       command: ["/bin/sh", "-c"]
-      args: ["echo 'data' > /mnt/datafile; sleep 99999"]
+      args: ["echo 'data' > /mnt/datafile; sync; sleep 99999"]
       volumeMounts:
         - name: data
           mountPath: "/mnt"
+  terminationGracePeriodSeconds: 2
   volumes:
     - name: data
       persistentVolumeClaim:

--- a/test-kuttl/e2e/simple-rsync/15-create-source.sh
+++ b/test-kuttl/e2e/simple-rsync/15-create-source.sh
@@ -18,5 +18,5 @@ spec:
   rsync:
     sshKeys: $KEYNAME
     address: $ADDRESS
-    copyMethod: Clone
+    copyMethod: Snapshot
 EOF

--- a/test-kuttl/e2e/simple-rsync/22-shutdown-source.yaml
+++ b/test-kuttl/e2e/simple-rsync/22-shutdown-source.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: v1
+  kind: Pod
+  name: source

--- a/test-kuttl/e2e/simple-rsync/30-verify-data.yaml
+++ b/test-kuttl/e2e/simple-rsync/30-verify-data.yaml
@@ -10,7 +10,7 @@ spec:
         - name: busybox
           image: busybox
           command: ["/bin/sh", "-c"]
-          args: ["diff -rs /mnt /mnt2"]
+          args: ["rm -rf /mnt/lost+found; rm -rf /mnt2/lost+found; diff -rs /mnt /mnt2"]
           volumeMounts:
             - name: data-src
               mountPath: "/mnt"


### PR DESCRIPTION
**Describe what this PR does**
Adds updates to the kuttl-based e2e suite so that it works in OpenShift on AWS

Overview of updates:
- EBS volumes can't be cloned, so `CopyMethod` must be `Snapshot`
- EBS volumes are locked to one AZ. The "verify" task must mount both the source and dest to do the compare, so they must both be provisioned from the same AZ. This is done via Pod affinity rules.
  - Adding pod affinity rules required an update to the Kind script to assign a topology label to the (single) kind node so that pods could still be scheduled when running there.
- Due to multi-node environment, the RWO volumes can only be accessed by a single Pod at a time, so the source bust be shut down prior to the verify job
- The source job needs to call `sync` before the snapshot happens or there's no guarantee the latest data will make it into the EBS snapshot.
- Mover containers all needed to call `sync` before exiting to ensure snapshots have all the data

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
