### PR TITLE
Add redirects: Scribe ==> VolSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,23 @@
-# Scribe
+# ~Scribe~ is now VolSync
+
+![Attention!](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png)
+
+**The Scribe project has been renamed to
+[VolSync](https://github.com/backube/volsync)!  
+As a part of the renaming process, this source repository and project
+documentation have moved.**
+
+Come find us at:
+
+* Code: [https://github.com/backube/volsync](https://github.com/backube/volsync).
+* Documentation: [https://volsync.readthedocs.io](https://volsync.readthedocs.io).
+
+------
+
+------
 
 Scribe asynchronously replicates Kubernetes persistent volumes between clusters
-using either rsync or rclone depending on the number of destinations.
-
-[![Documentation
-Status](https://readthedocs.org/projects/scribe-replication/badge/?version=latest)](https://scribe-replication.readthedocs.io/en/latest/?badge=latest)
-[![Go Report
-Card](https://goreportcard.com/badge/github.com/backube/scribe)](https://goreportcard.com/report/github.com/backube/scribe)
-[![codecov](https://codecov.io/gh/backube/scribe/branch/master/graph/badge.svg)](https://codecov.io/gh/backube/scribe)
-![maturity](https://img.shields.io/static/v1?label=maturity&message=alpha&color=red)
-
-![Documentation](https://github.com/backube/scribe/workflows/Documentation/badge.svg)
-![operator](https://github.com/backube/scribe/workflows/operator/badge.svg)
-
-## Getting started
-
-### Try Scribe in Kind
-
-For a convenient script to start a `kind cluster`, try this
-[script to setup a kind cluster](hack/setup-kind-cluster.sh).
-
-### Try Scribe in a Kind, Kubernetes, or Openshift cluster
-
-Follow the steps in the [installation
-instructions](https://scribe-replication.readthedocs.io/en/latest/installation/index.html).
-Here are
-[useful commands to configure cluster storage classes](https://scribe-replication.readthedocs.io/en/latest/installation/index.html#configure-default-csi-storage).
-
-## Scribe kubectl plugin
-
-To try out Scribe with a command line interface `scribe`:
-
-```bash
-make cli
-cp bin/kubectl-scribe /usr/local/bin/
-```
-
-**NOTE:** `scribe` tool is being actively developed. Options, flags,
-and names are likely to be updated frequently. PRs and new issues are welcome!
-
-Available commands:
-
-```bash
-kubectl scribe start-replication
-kubectl scribe set-replication
-kubectl scribe continue-replication
-kubectl scribe remove-replication
-```
-
-* Try the current examples:
-  * [single cluster cross namespace example](./docs/usage/rsync/db-example-cli.md)
-  * [multiple cluster example](./docs/usage/rsync/multi-context-sync-cli.md)
-
-## Helpful links
-
-* [Scribe documentation](https://scribe-replication.readthedocs.io)
-* [Changelog](CHANGELOG.md)
-* [Contributing guidelines](https://github.com/backube/.github/blob/master/CONTRIBUTING.md)
-* [Organization code of conduct](https://github.com/backube/.github/blob/master/CODE_OF_CONDUCT.md)
+using rsync, rclone, or restic.
 
 ## Licensing
 

--- a/docs/design/a-case-for.rst
+++ b/docs/design/a-case-for.rst
@@ -2,6 +2,8 @@
 A case for Scribe
 =================
 
+.. include:: ../renamed.rst
+
 .. contents::
    :depth: 2
 

--- a/docs/design/custom-resources.rst
+++ b/docs/design/custom-resources.rst
@@ -2,6 +2,8 @@
 Configuration and CRDs
 ======================
 
+.. include:: ../renamed.rst
+
 This document covers the rationale for how Scribe is configured and the
 structure of the CustomResourceDefinitions.
 

--- a/docs/design/index.rst
+++ b/docs/design/index.rst
@@ -2,6 +2,8 @@
 Enhancement proposals
 =====================
 
+.. include:: ../renamed.rst
+
 .. toctree::
    :titlesonly:
 

--- a/docs/design/mover-rsync.rst
+++ b/docs/design/mover-rsync.rst
@@ -2,6 +2,8 @@
 Rsync-based data mover
 ======================
 
+.. include:: ../renamed.rst
+
 This document covers the design of the rsync-based data mover.
 
 .. contents::

--- a/docs/design/restic.rst
+++ b/docs/design/restic.rst
@@ -2,6 +2,8 @@
 Restic-based data mover
 =======================
 
+.. include:: ../renamed.rst
+
 .. admonition:: Enhancement status
 
    Status: Proposed

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,8 @@ Overview
    usage/index
    design/index
 
+.. include:: ./renamed.rst
+
 *Asynchronous volume replication for Kubernetes CSI storage*
 
 Scribe is a Kubernetes operator that performs asynchronous replication of

--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -2,6 +2,8 @@
 Installation
 ============
 
+.. include:: ../renamed.rst
+
 The following directions will walk through the process of deploying Scribe.
 
 .. note::

--- a/docs/renamed.rst
+++ b/docs/renamed.rst
@@ -1,0 +1,8 @@
+.. attention:: **Scribe has been renamed to VolSync!**
+
+   The Scribe project has been renamed to **VolSync**, and it has a new home.
+   Come join us at our new location:
+
+   - Documentation: https://volsync.readthedocs.io
+   - Source: https://github.com/backube/volsync
+   - Artifact Hub: https://artifacthub.io/packages/helm/backube-helm-charts/volsync

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -2,6 +2,8 @@
 Usage
 =====
 
+.. include:: ../renamed.rst
+
 .. toctree::
    :hidden:
 

--- a/docs/usage/metrics/index.rst
+++ b/docs/usage/metrics/index.rst
@@ -2,6 +2,8 @@
 Metrics & monitoring
 ====================
 
+.. include:: ../../renamed.rst
+
 In order to support monitoring of replication relationships, Scribe exports a
 number of metrics that can be scraped with Prometheus. These metrics permit
 monitoring whether volumes are "in sync" and how long the synchronization

--- a/docs/usage/rclone/database_example.rst
+++ b/docs/usage/rclone/database_example.rst
@@ -2,6 +2,8 @@
 Rclone Database Example
 =======================
 
+.. include:: ../../renamed.rst
+
 The following example will use the Rclone replication method and take a Snapshot
 at the source. A MySQL database will be used as the example application.
 

--- a/docs/usage/rclone/index.rst
+++ b/docs/usage/rclone/index.rst
@@ -2,6 +2,8 @@
 Rclone-based replication
 ========================
 
+.. include:: ../../renamed.rst
+
 .. toctree::
    :hidden:
 

--- a/docs/usage/rclone/rclone-secret.rst
+++ b/docs/usage/rclone/rclone-secret.rst
@@ -2,6 +2,8 @@
 Understanding ``rclone-secret``
 ===============================
 
+.. include:: ../../renamed.rst
+
 What is ``rclone-secret``?
 ==========================
 

--- a/docs/usage/restic/database_example.rst
+++ b/docs/usage/restic/database_example.rst
@@ -2,6 +2,8 @@
 Restic Database Example
 =======================
 
+.. include:: ../../renamed.rst
+
 Restic backup
 =============
 

--- a/docs/usage/restic/index.rst
+++ b/docs/usage/restic/index.rst
@@ -2,6 +2,8 @@
 Restic-based backup
 ===================
 
+.. include:: ../../renamed.rst
+
 .. toctree::
    :hidden:
 

--- a/docs/usage/rsync/database_example.rst
+++ b/docs/usage/rsync/database_example.rst
@@ -2,6 +2,8 @@
 Rsync Database Example
 ======================
 
+.. include:: ../../renamed.rst
+
 The following example will use the Rsync replication method and take a Snapshot
 at the destination. A MySQL database will be used as the example application.
 

--- a/docs/usage/rsync/db_example_cli.rst
+++ b/docs/usage/rsync/db_example_cli.rst
@@ -2,6 +2,8 @@
 Rsync Database Plugin Example
 =============================
 
+.. include:: ../../renamed.rst
+
 This example will sync data from mysql database persistent volumes
 For this example, sync will happen within a single cluster and 2 namespaces.
 

--- a/docs/usage/rsync/external_rsync.rst
+++ b/docs/usage/rsync/external_rsync.rst
@@ -1,6 +1,8 @@
 ==============
 External Rsync
 ==============
+.. include:: ../../renamed.rst
+
 A situation may occur where data needs to be imported into a Kubernetes environment.
 In the Scribe repository, the script `bin/external-rsync-source` can be executed
 which will serve as the `replicationsource` allowing data to be replicated to a

--- a/docs/usage/rsync/index.rst
+++ b/docs/usage/rsync/index.rst
@@ -2,6 +2,8 @@
 Rsync-based replication
 =======================
 
+.. include:: ../../renamed.rst
+
 .. toctree::
    :hidden:
 

--- a/docs/usage/rsync/multi_context_sync_cli.rst
+++ b/docs/usage/rsync/multi_context_sync_cli.rst
@@ -2,6 +2,8 @@
 Rsync Database Cross-Cluster Plugin Example
 ===========================================
 
+.. include:: ../../renamed.rst
+
 This example will sync data from mysql database persistent volumes
 For this example, sync will happen between 2 clusters. Data will be synced
 from cluster-name :code:`api-source-com:6443` to cluster-name :code:`destination123`

--- a/docs/usage/rsync/plugin_opts.rst
+++ b/docs/usage/rsync/plugin_opts.rst
@@ -3,6 +3,8 @@
 Scribe Plugin Options with Defaults
 ====================================
 
+.. include:: ../../renamed.rst
+
 These may be passed as :code:`key: value` pairs in a file, on the command-line, or a combination of both.
 Command-line values override the config file values.
 

--- a/docs/usage/rsync/ssh_keys.rst
+++ b/docs/usage/rsync/ssh_keys.rst
@@ -2,6 +2,8 @@
 SSH keys
 ========
 
+.. include:: ../../renamed.rst
+
 Scribe generates SSH keys upon the deployment of a ReplicationDestination object
 but SSH keys can also be provided to Scribe rather than generating new ones. The
 steps below will describe the process to provide Scribe SSH keys.

--- a/docs/usage/triggers.rst
+++ b/docs/usage/triggers.rst
@@ -2,6 +2,8 @@
 Triggers
 ========
 
+.. include:: ../renamed.rst
+
 There are three types of triggers in scribe:
 
 1. Always - no trigger, always run.

--- a/helm/scribe/README.md
+++ b/helm/scribe/README.md
@@ -1,4 +1,25 @@
-# Scribe
+# ~Scribe~ is now VolSync
+
+![Attention!](https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Warning.svg/156px-Warning.svg.png)
+
+**The Scribe project has been renamed to
+[VolSync](https://github.com/backube/volsync)!  
+As a part of that process, some things have moved, including this Helm chart.**
+
+Please install the [VolSync
+chart](https://artifacthub.io/packages/helm/backube-helm-charts/volsync) instead
+of this one.
+
+Please update your links:
+
+- Source:
+  [https://github.com/backube/volsync](https://github.com/backube/volsync).
+- Documentation:
+  [https://volsync.readthedocs.io](https://volsync.readthedocs.io)
+- Helm chart:
+  [https://artifacthub.io/packages/helm/backube-helm-charts/volsync](https://artifacthub.io/packages/helm/backube-helm-charts/volsync)
+
+------
 
 Asynchronous volume replication for Kubernetes CSI storage
 

--- a/helm/scribe/templates/NOTES.txt
+++ b/helm/scribe/templates/NOTES.txt
@@ -3,3 +3,7 @@ The Scribe operator has been installed into the {{ .Release.Namespace }}
 namespace.
 
 Please see https://scribe-replication.readthedocs.org for documentation.
+
+IMPORTANT: Scribe has been renamed to VolSync, and this chart is no longer
+maintained. Please install the VolSync chart instead.
+https://artifacthub.io/packages/helm/backube-helm-charts/volsync


### PR DESCRIPTION
**Describe what this PR does**
The Scribe project is being renamed to VolSync. With that rename, the repo and docs are moving. This PR adds notices and points people to the new location.

- [x] Main README
- [x] scribe-replication.readthedocs.io
- [x] Helm chart description

**Is there anything that requires special attention?**
<!-- Do you have any questions? Did you do something clever? -->

**Related issues:**
<!-- Mention any github issues relevant to this PR -->
Related to #217 